### PR TITLE
WebSocket and summarizer thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ metta_data/
 venv
 .env
 public
-/venv
+# Ignore virtual environment folder
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ metta_data/
 venv
 .env
 public
+/venv

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,18 +1,27 @@
-from flask import Flask
-from flask_limiter import Limiter
-from flask_limiter.util import get_remote_address
-from app.services.schema_data import SchemaManager
-from app.services.cypher_generator import CypherQueryGenerator
-from app.services.metta_generator import MeTTa_Query_Generator
-from db import mongo_init
-from app.services.llm_handler import LLMHandler
-from app.persistence.storage_service import StorageService
 import os
 import logging
 import yaml
-
+from flask import Flask
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+from flask_socketio import SocketIO
+from app.services.schema_data import SchemaManager
+from app.services.cypher_generator import CypherQueryGenerator
+from app.services.metta_generator import MeTTa_Query_Generator
+from app.services.llm_handler import LLMHandler
+from app.persistence.storage_service import StorageService
+from db import mongo_init
+from flask_cors import CORS
+# Initialize Flask app
 app = Flask(__name__)
 
+
+# Set secret key
+app.config['SECRET_KEY'] = 'secret'
+
+socketio = SocketIO(app,cors_allowed_origins="*")
+CORS(app)
+# Function to load configuration from YAML file
 def load_config():
     config_path = os.path.join(os.path.dirname(__file__), '..', 'config', 'config.yaml')
     try:
@@ -27,34 +36,46 @@ def load_config():
         logging.error(f"Error parsing YAML file: {e}")
         raise
 
+# Load configuration
 config = load_config()
 
+# Initialize rate limiter
 limiter = Limiter(
     get_remote_address,
     app=app,
     default_limits=["200 per minute"],
 )
 
+# Initialize MongoDB connection
 mongo_init()
 
+# Initialize database instances based on configuration
 databases = {
     "metta": lambda: MeTTa_Query_Generator("./Data"),
-    "cypher": lambda: CypherQueryGenerator("./cypher_data")
-    
+    "cypher": lambda: CypherQueryGenerator("./cypher_data"),
     # Add other database instances here
 }
 
-database_type = config['database']['type']
+# Fetch the database type from the configuration
+database_type = config.get('database', {}).get('type')
+if database_type not in databases:
+    raise ValueError(f"Unsupported database type: {database_type}")
+
 db_instance = databases[database_type]()
 
-llm = LLMHandler()  # Initialize the LLMHandler
-storage_service = StorageService() # Initialize the storage service
+# Initialize LLM handler and storage service
+llm = LLMHandler()
+storage_service = StorageService()
 
+# Store handlers in app config for global access
 app.config['llm_handler'] = llm
 app.config['storage_service'] = storage_service
 
-schema_manager = SchemaManager(schema_config_path='./config/schema_config.yaml', biocypher_config_path='./config/biocypher_config.yaml')
+# Initialize schema manager
+schema_manager = SchemaManager(
+    schema_config_path='./config/schema_config.yaml',
+    biocypher_config_path='./config/biocypher_config.yaml'
+)
 
 # Import routes at the end to avoid circular imports
 from app import routes
-

--- a/app/lib/validator.py
+++ b/app/lib/validator.py
@@ -69,7 +69,7 @@ def validate_request(request, schema):
             source_type = node_map[predicate['source']]['type']
             target_type = node_map[predicate['target']]['type']
 
-            predicate_type = f'{source_type}-{predicate_type}-{target_type}'
+            predicate_type = f'{source_type}_{predicate_type}_{target_type}'
             if predicate_type not in schema:
                 raise Exception(f"Invalid source and target for the predicate {predicate['type']}")
     return node_map

--- a/app/models/storage.py
+++ b/app/models/storage.py
@@ -36,6 +36,8 @@ class Storage(Schema):
             "node_types": [{
                 "type": Types.String,
             }],
+            "node_count_by_label": any,
+            "edge_count_by_label": any,
             "title": {
                 "type": Types.String,
                 "required": True,

--- a/app/persistence/storage_service.py
+++ b/app/persistence/storage_service.py
@@ -4,18 +4,20 @@ class StorageService():
     def __init__(self):
         pass
     
-    def save(self, user_id, data, title, summary, question, answer, node_count, edge_count, node_types):
+    def save(self, annotation):
         data = Storage(
-                user_id=user_id,
-                query=data,
-                title=title,
-                summary=summary,
-                question=question,
-                answer=answer,
-                node_count=node_count,
-                edge_count=edge_count,
-                node_types=node_types
-                )
+            user_id=annotation["current_user_id"],
+            query=annotation["query"],
+            title=annotation["title"],
+            summary=annotation["summary"],
+            question=annotation["question"],
+            answer=annotation["answer"],
+            node_count=annotation["node_count"],
+            edge_count=annotation["edge_count"],
+            node_types=annotation["node_types"],
+            node_count_by_label=annotation["node_count_by_label"],
+            edge_count_by_label=annotation["edge_count_by_label"]
+            )
 
         id = data.save()
         return id

--- a/app/routes.py
+++ b/app/routes.py
@@ -277,7 +277,7 @@ def process_by_id(current_user_id, id):
 
     try:       
         # Run the query and parse the results
-        result = db_instance.run_query(query, limit)
+        result = db_instance.run_query(query)
         response_data = db_instance.parse_and_serialize(result, schema_manager.schema, properties)
         
         response_data["annotation_id"] = str(annotation_id)

--- a/app/routes.py
+++ b/app/routes.py
@@ -135,10 +135,12 @@ def process_query(current_user_id):
 
         if existing_query is None:
             title = llm.generate_title(query_code)
-            summary = llm.generate_summary(response_data)
-            
-            if summary is None:
-                 summary = 'Graph too big, could not summarize'
+
+            if not response_data.get('nodes') and not response_data.get('edges'):
+                summary = 'No data found for the query'
+            else:
+                summary = llm.generate_summary(response_data) or 'Graph too big, could not summarize'
+
             answer = llm.generate_summary(response_data, question, True, summary) if question else None
             node_count = response_data['node_count']
             edge_count = response_data['edge_count'] if "edge_count" in response_data else 0

--- a/app/routes.py
+++ b/app/routes.py
@@ -88,22 +88,19 @@ def on_leave(data):
     room = data['room']
     leave_room(room)
     send(f"{username} has left the room.", to=room)
-
-
 @app.route('/query', methods=['POST'])
 @token_required
 def process_query(current_user_id):
     data = request.get_json()
     if not data or 'requests' not in data:
         return jsonify({"error": "Missing requests data"}), 400
-
-    # Extract query parameters
+    
     limit = request.args.get('limit')
     properties = request.args.get('properties')
-    source = request.args.get('source', 'hypotehesis')  # Default to 'hypotehesis'
-
+    source = request.args.get('source') # can be either hypotehesis or ai_assistant
+    
     if properties:
-        properties = bool(properties.lower() in ['true', '1', 'yes'])
+        properties = bool(strtobool(properties))
     else:
         properties = False
 
@@ -114,37 +111,50 @@ def process_query(current_user_id):
             return jsonify({"error": "Invalid limit value. It should be an integer."}), 400
     else:
         limit = None
-
     try:
         requests = data['requests']
-        annotation_id = requests.get('annotation_id')
-        question = requests.get('question')
+        annotation_id = None
+        question = None
+        answer = None
+        
+        if 'annotation_id' in requests:
+            annotation_id = requests['annotation_id'] 
+        
+        if 'question' in requests:
+            question = requests['question']
 
         # Validate the request data before processing
         node_map = validate_request(requests, schema_manager.schema)
         if node_map is None:
             return jsonify({"error": "Invalid node_map returned by validate_request"}), 400
 
-        # Convert ID to the appropriate format
+        #convert id to appropriate format
         requests = db_instance.parse_id(requests)
 
         # Generate the query code
         query_code = db_instance.query_Generator(requests, node_map, limit)
-
+        
         # Run the query and parse the results
         result = db_instance.run_query(query_code, source)
         response_data = db_instance.parse_and_serialize(result, schema_manager.schema, properties)
 
         # Extract node types
         nodes = requests['nodes']
-        node_types = list({node["type"] for node in nodes})
+        node_types = set()
 
-        # Process query_code for consistent LIMIT placeholder
+        for node in nodes:
+            node_types.add(node["type"])
+
+        node_types = list(node_types)
+
         if isinstance(query_code, list):
             query_code = query_code[0]
-            query_code = re.sub(r'LIMIT\s+\d+', 'LIMIT {PLACEHOLDER}', query_code)
 
-        # Summarization logic
+        if source == 'hypotehesis':
+            response = {"nodes": response_data['nodes'], "edges": response_data['edges']}
+            formatted_response = json.dumps(response, indent=4)
+            return Response(formatted_response, mimetype='application/json')
+
         if annotation_id:
             existing_query = storage_service.get_user_query(annotation_id, str(current_user_id), query_code)
         else:
@@ -156,7 +166,6 @@ def process_query(current_user_id):
             if not response_data.get('nodes') and not response_data.get('edges'):
                 summary = 'No data found for the query'
             else:
-                # Run summarization in a separate thread
                 def summarizer_thread():
                     room = requests.get('room')
                     message = data.get('message')
@@ -165,7 +174,7 @@ def process_query(current_user_id):
                     socketio.emit('message', f"{data.get('username')}: {message}", to=room)
 
                         # Example summarization logic (assuming response_data contains the text for summarization)
-                    response_data = message  # Use the message or data to generate the summary
+                 
                     summary = llm.generate_summary(response_data) or 'Graph too big, could not summarize'
                         
                     print("******************************* Summary Generated **********************************************")
@@ -179,44 +188,40 @@ def process_query(current_user_id):
                                     
                 sender = threading.Thread(name="summarizer_thread", target=summarizer_thread)
                 sender.start()
-
             answer = llm.generate_summary(response_data, question, True, summary) if question else None
-
             node_count = response_data['node_count']
             edge_count = response_data['edge_count'] if "edge_count" in response_data else 0
             node_count_by_label = response_data['node_count_by_label']
             edge_count_by_label = response_data['edge_count_by_label'] if "edge_count_by_label" in response_data else []
-            print("step 1 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
             if annotation_id is not None:
-                annotation = {"query": query_code, "summary": summary, "node_count": node_count,
+                annotation = {"query": query_code, "summary": summary, "node_count": node_count, 
                               "edge_count": edge_count, "node_types": node_types, "node_count_by_label": node_count_by_label,
                               "edge_count_by_label": edge_count_by_label, "updated_at": datetime.datetime.now()}
                 storage_service.update(annotation_id, annotation)
             else:
-                print("step 2 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
                 annotation = {"current_user_id": str(current_user_id), "query": query_code,
                               "question": question, "answer": answer,
                               "title": title, "summary": "", "node_count": node_count,
-                              "edge_count": edge_count, "node_types": node_types,
+                              "edge_count": edge_count, "node_types": node_types, 
                               "node_count_by_label": node_count_by_label, "edge_count_by_label": edge_count_by_label}
                 annotation_id = storage_service.save(annotation)
-                print("22___________________________")
         else:
             title, summary, annotation_id = '', '', ''
-        print("step 3 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
+
         if existing_query:
             title = existing_query.title
-            #summary = existing_query.summary
+            summary = existing_query.summary
             annotation_id = existing_query.id
             storage_service.update(annotation_id, {"updated_at": datetime.datetime.now()})
 
+        
         updated_data = storage_service.get_by_id(annotation_id)
-        print("step 5 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
+
         response_data["title"] = title
+        
         response_data["annotation_id"] = str(annotation_id)
         response_data["created_at"] = updated_data.created_at.isoformat()
         response_data["updated_at"] = updated_data.updated_at.isoformat()
-        response_data = {"nodes": response_data['nodes'], "edges": response_data['edges']}
 
         if question:
             response_data["question"] = question
@@ -224,15 +229,17 @@ def process_query(current_user_id):
         if answer:
             response_data["answer"] = answer
 
-        if source == 'ai-assistant':
+        if source=='ai-assistant':
             response = {"annotation_id": str(annotation_id), "question": question, "answer": answer}
             formatted_response = json.dumps(response, indent=4)
             return Response(formatted_response, mimetype='application/json')
-        print("step 6 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
+
+        # if limit:
+        #     response_data = limit_graph(response_data, limit)
+
         formatted_response = json.dumps(response_data, indent=4)
         logging.info(f"\n\n============== Query ==============\n\n{query_code}")
         return Response(formatted_response, mimetype='application/json')
-
     except Exception as e:
         logging.error(f"Error processing query: {e}")
         return jsonify({"error": str(e)}), 500

--- a/app/routes.py
+++ b/app/routes.py
@@ -280,7 +280,7 @@ def process_by_id(current_user_id, id):
         properties = bool(strtobool(properties))
     else:
         properties = False
-
+ 
     if limit:
         try:
             limit = int(limit)
@@ -290,9 +290,13 @@ def process_by_id(current_user_id, id):
         limit = None
 
 
-    try:       
+    try: 
+       
+        query=query.replace("{PLACEHOLDER}",str(limit)) 
+       
         # Run the query and parse the results
         result = db_instance.run_query(query)
+      
         response_data = db_instance.parse_and_serialize(result, schema_manager.schema, properties)
         
         response_data["annotation_id"] = str(annotation_id)

--- a/app/routes.py
+++ b/app/routes.py
@@ -345,7 +345,7 @@ def process_full_data(current_user_id, annotation_id):
             return link
     
         # Run the query and parse the results
-        result = db_instance.run_query(query, None, apply_limit=False)
+        result = db_instance.run_query(query)
         parsed_result = db_instance.convert_to_dict(result, schema_manager.schema)
 
         file_path = convert_to_csv(parsed_result, user_id= current_user_id, file_name=title)

--- a/app/routes.py
+++ b/app/routes.py
@@ -128,7 +128,8 @@ def process_query(current_user_id):
 
         if isinstance(query_code, list):
             query_code = query_code[0]
-
+            import re
+            query_code=re.sub(r'LIMIT\s+\d+', 'LIMIT {PLACEHOLDER}', query_code)
         if source == 'hypotehesis':
             response = {"nodes": response_data['nodes'], "edges": response_data['edges']}
             formatted_response = json.dumps(response, indent=4)
@@ -136,6 +137,7 @@ def process_query(current_user_id):
 
         if annotation_id:
             existing_query = storage_service.get_user_query(annotation_id, str(current_user_id), query_code)
+            print("it use already saved existing query ")
         else:
             existing_query = None
 
@@ -153,11 +155,13 @@ def process_query(current_user_id):
             node_count_by_label = response_data['node_count_by_label']
             edge_count_by_label = response_data['edge_count_by_label'] if "edge_count_by_label" in response_data else []
             if annotation_id is not None:
+                print("step 1 query CODE -----------------------------_____________________________((((((((((((((((((((_____________________-", query_code)
                 annotation = {"query": query_code, "summary": summary, "node_count": node_count, 
                               "edge_count": edge_count, "node_types": node_types, "node_count_by_label": node_count_by_label,
                               "edge_count_by_label": edge_count_by_label, "updated_at": datetime.datetime.now()}
                 storage_service.update(annotation_id, annotation)
             else:
+                print("step 2 query CODE  ***************************((((((((((((((((((((((((((((((((((((((***", query_code)
                 annotation = {"current_user_id": str(current_user_id), "query": query_code,
                               "question": question, "answer": answer,
                               "title": title, "summary": summary, "node_count": node_count,

--- a/app/routes.py
+++ b/app/routes.py
@@ -101,7 +101,7 @@ def process_query(current_user_id):
         
         if 'question' in requests:
             question = requests['question']
-        
+
         # Validate the request data before processing
         node_map = validate_request(requests, schema_manager.schema)
         if node_map is None:

--- a/app/routes.py
+++ b/app/routes.py
@@ -342,8 +342,20 @@ def process_full_data(current_user_id, annotation_id):
 
     if cursor is None:
         return None
-    
     query, title = cursor.query, cursor.title
+    print("query 0 and 1 indexed________________________________________________________________________________________________")
+    print(query)
+    print("_______________________________________________________________________________________________________________")
+    
+    import re
+    if "LIMIT" in query:
+        query = re.sub(r'\s+LIMIT\s+\d+', '', query)
+     
+
+    print("query 0 and 1 indexed________________________________________________________________________________________________")
+    print(query)
+    print("_______________________________________________________________________________________________________________")
+
     
     try:
         file_path = generate_file_path(file_name=title, user_id=current_user_id, extension='xls')
@@ -354,9 +366,10 @@ def process_full_data(current_user_id, annotation_id):
             link = f'{request.host_url}{file_path}'
 
             return link
-    
+        
         # Run the query and parse the results
-        result = db_instance.run_query(query)
+        result = db_instance.run_query(query,source=None)
+        print("step2 ")
         parsed_result = db_instance.convert_to_dict(result, schema_manager.schema)
 
         file_path = convert_to_csv(parsed_result, user_id= current_user_id, file_name=title)

--- a/app/routes.py
+++ b/app/routes.py
@@ -343,19 +343,13 @@ def process_full_data(current_user_id, annotation_id):
     if cursor is None:
         return None
     query, title = cursor.query, cursor.title
-    print("query 0 and 1 indexed________________________________________________________________________________________________")
-    print(query)
-    print("_______________________________________________________________________________________________________________")
-    
+    #remove the limit 
     import re
     if "LIMIT" in query:
         query = re.sub(r'\s+LIMIT\s+\d+', '', query)
      
 
-    print("query 0 and 1 indexed________________________________________________________________________________________________")
-    print(query)
-    print("_______________________________________________________________________________________________________________")
-
+     
     
     try:
         file_path = generate_file_path(file_name=title, user_id=current_user_id, extension='xls')
@@ -368,6 +362,7 @@ def process_full_data(current_user_id, annotation_id):
             return link
         
         # Run the query and parse the results
+        # query code inputs 2 value so source=None
         result = db_instance.run_query(query,source=None)
         print("step2 ")
         parsed_result = db_instance.convert_to_dict(result, schema_manager.schema)

--- a/app/routes.py
+++ b/app/routes.py
@@ -132,15 +132,12 @@ def process_query(current_user_id):
         if source == 'hypotehesis':
             response = {"nodes": response_data['nodes'], "edges": response_data['edges']}
             formatted_response = json.dumps(response, indent=4)
-            logging.info(f"\n\n============== Query ==============\n\n{query_code}")
             return Response(formatted_response, mimetype='application/json')
 
         if annotation_id:
             existing_query = storage_service.get_user_query(annotation_id, str(current_user_id), query_code)
         else:
             existing_query = None
-
-        print("------ EXISTING QUYERY ------", existing_query)
 
         if existing_query is None:
             title = llm.generate_title(query_code)

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -243,27 +243,74 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             if 'where_preds' in query_clauses and query_clauses['where_preds']:
                 where_clause = f"WHERE {' AND '.join(query_clauses['where_preds'])}"
 
+        query_clauses['list_of_node_ids'].extend(query_clauses['return_no_preds'])
+
         # Construct the COUNT clause
-        if 'return_no_preds' in query_clauses and 'return_preds' in query_clauses:
-            query_clauses['list_of_node_ids'].extend(query_clauses['return_no_preds'])
-        for node_ids in query_clauses['list_of_node_ids']:
-            count_clause += f"COLLECT(DISTINCT {node_ids}) AS {node_ids}_count, "
+        count_clause = f"{' + '.join([f'COLLECT(DISTINCT {node})' for node in query_clauses['list_of_node_ids']])} AS combined_nodes"
         if 'return_preds' in query_clauses:
-            for edge_ids in query_clauses['return_preds']:
-                count_clause += f"COLLECT(DISTINCT {edge_ids}) AS {edge_ids}_count, "
-        count_clause = f"WITH {count_clause.rstrip(', ')}"
+            count_clause += ", " + " + ".join([f"COLLECT(DISTINCT {edge})" for edge in query_clauses['return_preds']]) + " AS combined_edges"
+        count_clause = f"WITH {count_clause}"
 
-
-        # Construct the WITH and UNWIND clauses
-        combined_nodes = ' + '.join([f"{var}_count" for var in query_clauses['list_of_node_ids']])
-        combined_edges = None
         if 'return_preds' in query_clauses:
-            combined_edges = ' + '.join([f"{var}_count" for var in query_clauses['return_preds']])
-        with_clause = f"WITH {combined_nodes} AS combined_nodes {f',{combined_edges} AS combined_edges' if combined_edges else ''}"
-        unwind_clause = f"UNWIND combined_nodes AS nodes"
-
-        # Construct the RETURN clause
-        return_clause = f"RETURN COUNT(DISTINCT nodes) AS total_nodes {', SIZE(combined_edges) AS total_edges ' if combined_edges else ''}"
+            unwind_clause = '''
+                UNWIND combined_nodes AS nodes
+                UNWIND combined_nodes AS node_e
+                UNWIND labels(nodes) AS label
+            '''
+            with_clause = '''
+                WITH
+                    label,
+                    node_e,
+                    COUNT(DISTINCT nodes) AS node_count, 
+                    combined_nodes,
+                    combined_edges
+                ORDER BY label
+                WITH
+                    label,
+                    node_count,
+                    node_e,
+                    combined_edges
+                UNWIND combined_edges AS edges
+                WITH 
+                    label,
+                    node_count,
+                    TYPE(edges) AS edge_type,
+                    COUNT(edges) AS edge_count,
+                    node_e,
+                    combined_edges
+                WITH 
+                    COLLECT(DISTINCT {label: label, count: node_count}) AS nodes_count_by_label,
+                    COLLECT(DISTINCT {label: edge_type, count: edge_count}) AS edges_count_by_type,
+                    COUNT(DISTINCT(node_e)) AS total_nodes,
+                    SIZE(combined_edges) AS total_edges
+            '''
+            return_clause = '''
+                RETURN    
+                    nodes_count_by_label,
+                    edges_count_by_type,
+                    total_nodes,
+                    total_edges
+            '''
+        else:
+            unwind_clause = '''
+                UNWIND combined_nodes AS nodes
+                UNWIND labels(nodes) AS label
+            '''
+            with_clause = '''
+                WITH
+                    label,
+                    COUNT(DISTINCT nodes) AS node_count, 
+                    combined_nodes
+                ORDER BY label
+                WITH 
+                    COLLECT(DISTINCT {label: label, count: node_count}) AS nodes_count_by_label,
+                    node_count AS total_nodes
+            '''
+            return_clause = '''
+                RETURN    
+                    nodes_count_by_label,
+                    total_nodes
+            '''
 
         query = f'''
             {match_no_clause}
@@ -271,8 +318,8 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             {match_clause}
             {where_clause}
             {count_clause}
-            {with_clause}
             {unwind_clause}
+            {with_clause}
             {return_clause}
         '''
         return query
@@ -333,15 +380,18 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         return properties
 
     def parse_neo4j_results(self, results, all_properties):
-        (nodes, edges, _, _, node_count, edge_count) = self.process_result(results, all_properties)
-        return {"nodes": nodes, "edges": edges, "node_count": node_count, "edge_count": edge_count}
+        (nodes, edges, _, _, meta_data) = self.process_result(results, all_properties)
+        return {"nodes": nodes, "edges": edges, "node_count": meta_data['node_count'], 
+                "edge_count": meta_data['edge_count'], "node_count_by_label": meta_data['node_count_by_label'], 
+                "edge_count_by_label": meta_data['edge_count_by_label']
+                }
 
     def parse_and_serialize(self, input, schema, all_properties):
         parsed_result = self.parse_neo4j_results(input, all_properties)
         return parsed_result
 
     def convert_to_dict(self, results, schema):
-        (_, _, node_dict, edge_dict, _, _) = self.process_result(results, True)
+        (_, _, node_dict, edge_dict, _) = self.process_result(results, True)
         return (node_dict, edge_dict)
 
     def process_result(self, results, all_properties):
@@ -419,10 +469,19 @@ class CypherQueryGenerator(QueryGeneratorInterface):
 
         if count_result:
             for count_record in count_result:
+                node_count_by_label = count_record['nodes_count_by_label']
+                edge_count_by_label = count_record.get('edges_count_by_type', [])
                 node_count = count_record['total_nodes']
                 edge_count = count_record.get('total_edges', 0)
+
+        meta_data = {
+            "node_count": node_count,
+            "edge_count": edge_count,
+            "node_count_by_label": node_count_by_label,
+            "edge_count_by_label": edge_count_by_label
+        }
     
-        return (nodes, edges, node_to_dict, edge_to_dict, node_count, edge_count)
+        return (nodes, edges, node_to_dict, edge_to_dict, meta_data)
 
     def parse_id(self, request):
         nodes = request["nodes"]

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -282,13 +282,13 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         if return_preds:
             count_relationships = (
             'WITH nodes_count_by_label, ' +
-            ' + '.join([f'COLLECT([type(r{i}), r{i}])' for i in range(len(query_clauses['predicates']))]) +
+            ' + '.join([f'COLLECT(DISTINCT r{i})' for i in range(len(query_clauses['predicates']))]) +
             ' AS relationships'
             )
             unwind_relationships = 'UNWIND relationships AS rel'
             count_edge_by_label = (
-            'WITH nodes_count_by_label, rel[0] AS edge_type, COUNT(rel[1]) AS edge_count '
-            'WITH nodes_count_by_label, COLLECT({label: edge_type, count: edge_count}) AS edges_count_by_type'
+            'WITH nodes_count_by_label, TYPE(rel) AS relationship_type, COUNT(rel) AS edge_count '
+            'WITH nodes_count_by_label, COLLECT(DISTINCT {relationship_type: relationship_type, count: edge_count}) AS edges_count_by_type'
             )
             return_clause = (
             'RETURN nodes_count_by_label, edges_count_by_type, '

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -156,7 +156,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                     "full_return_preds": full_return_preds,
                     "where_preds": where_preds,
                     "list_of_node_ids": list_of_node_ids,
-                    "return_preds": return_preds
+                    "return_preds": return_preds,
                 }
                 count = self.construct_count_clause(query_clauses)
                 cypher_queries.append(count)
@@ -243,7 +243,8 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             if 'where_preds' in query_clauses and query_clauses['where_preds']:
                 where_clause = f"WHERE {' AND '.join(query_clauses['where_preds'])}"
 
-        query_clauses['list_of_node_ids'].extend(query_clauses['return_no_preds'])
+        if "return_no_preds" in query_clauses:
+            query_clauses['list_of_node_ids'].extend(query_clauses['return_no_preds'])
 
         # Construct the COUNT clause
         count_clause = f"{' + '.join([f'COLLECT(DISTINCT {node})' for node in query_clauses['list_of_node_ids']])} AS combined_nodes"

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -464,7 +464,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                     edge_data = {
                         "data": {
                             # "id": item.id,
-                            "label_id": f"{source_label}-{item.type}-{target_label}",
+                            "id": f"{source_label}_{item.type}_{target_label}",
                             "label": item.type,
                             "source": source_id,
                             "target": target_id,

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -269,7 +269,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         if return_preds:
             for index, predicate in enumerate(query_clauses['predicates']):
                 count_clause.append(f'WHEN label IN labels(startNode(r{index})) THEN startNode(r{index})')
-            count_clause.append(f'WHEN label IN labels(endNode(r{index})) THEN endNode(r{index})')
+                count_clause.append(f'WHEN label IN labels(endNode(r{index})) THEN endNode(r{index})')
         else:
             for node_id in query_clauses['list_of_node_ids']:
                 count_clause.append(f'WHEN label IN labels({node_id}) THEN {node_id}')

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -1,3 +1,4 @@
+import json
 from typing import List
 import logging
 from dotenv import load_dotenv
@@ -56,7 +57,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
 
         logger.info(f"Finished loading {len(nodes_paths)} nodes and {len(edges_paths)} edges datasets.")
 
-    def run_query(self, query_code, source=None):
+    def run_query(self, query_code, source):
         results = []
         if isinstance(query_code, list):
             find_query = query_code[0]
@@ -71,273 +72,575 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             try:
                 with self.driver.session() as session:
                     results.append(list(session.run(count_query)))
-            except:
+            except Exception as e:
+                print(e)
+                print("EXCPETION")
                 results.append([])
                 return results
-
         return results
 
     def query_Generator(self, requests, node_map, limit=None):
         nodes = requests['nodes']
+        predicates = requests.get("predicates", [])
+        logic = requests.get("logic", None)
+        commands = self._initialize_commands()
+        
+        node_predicates, predicate_map = self._prepare_predicate_maps(predicates, logic)      
+        if logic:
+            for child in logic['children']:
+                commands = self._process_logic_child(child, node_map, predicate_map, node_predicates, commands)
+        commands, list_of_node_ids= self.generate_sub_commands(nodes, predicates, node_map, logic, commands)
+        cypher_qureies = self.build_queries(commands, list_of_node_ids, predicates, limit)
 
-        if "predicates" in requests:
-            predicates = requests["predicates"]
-        else:
-            predicates = None
+        return cypher_qureies
+    def _prepare_predicate_maps(self, predicates, logic):
+        node_predicates = {p['source'] for p in predicates}.union({p['target'] for p in predicates})
+        predicate_map = {}
 
-        cypher_queries = []
-        # node_dict = {node['node_id']: node for node in nodes}
+        if logic:
+            for predicate in predicates:
+                if predicate['predicate_id'] not in predicate_map:
+                    predicate_map[predicate['predicate_id']] = predicate
+                else:
+                    raise Exception('Repeated predicate_id')
 
-        match_preds = []
-        return_preds = []
-        where_preds = []
-        match_no_preds = []
-        return_no_preds = []
-        where_no_preds = []
-        node_ids = set()
-        # Track nodes that are included in relationships
-        used_nodes = set()
-        if not predicates:
-            list_of_node_ids = []
-            # Case when there are no predicates
-            for node in nodes:
-                var_name = f"n_{node['node_id']}"
-                match_no_preds.append(self.match_node(node, var_name))
-                if node['properties']:
-                    where_no_preds.extend(self.where_construct(node, var_name))
-                return_no_preds.append(var_name)
-                list_of_node_ids.append(var_name)
-            cypher_query = self.construct_clause(match_no_preds, return_no_preds, where_no_preds, limit)
-            cypher_queries.append(cypher_query)
-            query_clauses = {
-                    "match_no_preds": match_no_preds,
-                    "return_no_preds": return_no_preds,
-                    "where_no_preds": where_no_preds,
-                    "list_of_node_ids": list_of_node_ids,
-                    "predicates": predicates
-                }
-            count = self.construct_count_clause(query_clauses)
-            cypher_queries.append(count)
-        else:
-            for i, predicate in enumerate(predicates):
-                predicate_type = predicate['type'].replace(" ", "_").lower()
-                source_node = node_map[predicate['source']]
-                target_node = node_map[predicate['target']]
-                source_var = source_node['node_id']
-                target_var = target_node['node_id']
+        return node_predicates, predicate_map
+    def _initialize_commands(self):
+        return {
+            "preds": {
+                "match": [],
+                "where": [],
+                "return": [],
+                "optional_match": [],
+                "optional_where": [],
+                "optional_return": [],
+                "with": [],
+                "no_node_labels": set(),
+                "no_predicate_labels": set()
+            },
+            "no_preds": {
+                "match": [],
+                "where": [],
+                "return": [],
+                "no_node_labels": set()
+            }
+        }
 
-                source_match = self.match_node(source_node, source_var)
-                where_preds.extend(self.where_construct(source_node, source_var))
-                match_preds.append(source_match)
-                target_match = self.match_node(target_node, target_var)
-                where_preds.extend(self.where_construct(target_node, target_var))
-
-                match_preds.append(f"({source_var})-[r{i}:{predicate_type}]->{target_match}")
-                return_preds.append(f"r{i}")
-
-                used_nodes.add(predicate['source'])
-                used_nodes.add(predicate['target'])
-                node_ids.add(source_var)
-                node_ids.add(target_var)
-
-            for node_id, node in node_map.items():
-                if node_id not in used_nodes:
-                    var_name = f"n_{node_id}"
-                    match_no_preds.append(self.match_node(node, var_name))
-                    where_no_preds.extend(self.where_construct(node, var_name))
-                    return_no_preds.append(var_name)
-
-            list_of_node_ids = list(node_ids)
-            list_of_node_ids.sort()
-            full_return_preds = return_preds + list_of_node_ids
-                
-            if (len(match_no_preds) == 0):
-                cypher_query = self.construct_clause(match_preds, full_return_preds, where_preds, limit)
-                cypher_queries.append(cypher_query)
-
-                query_clauses = {
-                    "match_preds": match_preds, 
-                    "full_return_preds": full_return_preds,
-                    "where_preds": where_preds,
-                    "list_of_node_ids": list_of_node_ids,
-                    "return_preds": return_preds,
-                    "predicates": predicates
-                }
-                count = self.construct_count_clause(query_clauses)
-                cypher_queries.append(count)
-            else:
-                query_clauses = {
-                    "match_preds": match_preds, 
-                    "full_return_preds": full_return_preds,
-                    "where_preds": where_preds,
-                    "match_no_preds": match_no_preds,
-                    "return_no_preds": return_no_preds,
-                    "where_no_preds": where_no_preds,
-                    "list_of_node_ids": list_of_node_ids,
-                    "return_preds": return_preds,
-                    "predicates": predicates
-                }
-                cypher_query = self.construct_union_clause(query_clauses, limit)
-                cypher_queries.append(cypher_query)
-
-                count = self.construct_count_clause(query_clauses)
-                cypher_queries.append(count)
-        return cypher_queries
+    def _process_logic_child(self, child, node_map, predicate_map, node_predicates, commands):
+        operator = child["operator"]
+        if operator == "NOT":
+            return self.construct_not_operation(child, node_map, predicate_map, node_predicates, commands)
+        elif operator == "OR":
+            return self.construct_or_operation(child, node_map, predicate_map, node_predicates, commands)
+        return commands
     
-    def construct_clause(self, match_clause, return_clause, where_no_preds, limit):
-        match_clause = f"MATCH {', '.join(match_clause)}"
-        return_clause = f"RETURN {', '.join(return_clause)}"
-        if len(where_no_preds) > 0:
-            where_clause = f"WHERE {' AND '.join(where_no_preds)}"
+    def build_queries(self, commands, list_of_node_ids, predicates, limit):
+        cypher_queries = []
+        
+        if not predicates:
+            cypher_queries.extend(self._build_no_predicate_queries(commands, list_of_node_ids, limit))
+        else:
+            cypher_queries.extend(self._build_predicate_queries(commands, list_of_node_ids, predicates, limit))
+
+        return cypher_queries
+
+    def _build_no_predicate_queries(self, commands, list_of_node_ids, limit):
+        queries = []
+
+        query_clauses = {
+            "match_clause": commands['no_preds']['match'],
+            "return_clause": commands['no_preds']['return'],
+            "where_clause": commands['no_preds']['where']
+        }
+        queries.append(self.construct_clause(query_clauses, limit))
+
+        count_clauses = {
+            "match_no_preds": commands['no_preds']['match'],
+            "return_no_preds": commands['no_preds']['return'],
+            "where_no_preds": commands['no_preds']['where'],
+            "list_of_node_ids": list_of_node_ids,
+            "predicates": []
+        }
+        queries.append(self.construct_count_clause(count_clauses))
+
+        return queries
+
+    def _build_predicate_queries(self, commands, list_of_node_ids, predicates, limit):
+        queries = []
+        full_return_preds = list(set(commands['preds']['return'] + list_of_node_ids))
+
+        union_clauses = {
+            "match_preds": commands['preds']['match'], 
+            "full_return_preds": full_return_preds,
+            "where_preds": commands['preds']['where'],
+            "match_no_preds": commands['no_preds']['match'],
+            "return_no_preds": commands['no_preds']['return'],
+            "where_no_preds": commands['no_preds']['where'],
+            "list_of_node_ids": list_of_node_ids,
+            "optional_match": commands['preds']['optional_match'],
+            "optional_where": commands['preds']['optional_where'],
+            "optional_return": commands['preds']['optional_return'],
+            "optional_with": commands['preds']['with'],
+            "return_preds": commands['preds']['return'],
+            "predicates": predicates
+        }
+        queries.append(self.construct_union_clause(union_clauses, limit))
+
+        count_clauses = union_clauses.copy()
+        queries.append(self.construct_count_clause(count_clauses))
+
+        return queries
+
+
+    MATCH_NO_PRED_LABELS = 'no_predicate_lables'
+    def generate_sub_commands(self, nodes, predicates, node_map, logic, commands):
+        list_of_node_ids = set()
+        
+        if not predicates:
+            self._handle_no_predicates(nodes, commands, list_of_node_ids)
+        else:
+            self._handle_with_predicates(predicates, node_map, logic, commands, list_of_node_ids)
+        
+        return commands, list(list_of_node_ids)
+    
+    def _handle_no_predicates(self, nodes, commands, list_of_node_ids):
+        for node in nodes:
+            if node['properties']:
+                commands['no_preds']['where'].extend(self.where_construct(node))
+            list_of_node_ids.add(node['node_id'])
+            no_node_labels = commands['no_preds']['no_node_labels']
+            commands['no_preds']['match'].append(self.match_node(node, no_node_labels if no_node_labels else None))
+            commands['no_preds']['return'].append(node['node_id'])
+    
+    def _handle_with_predicates(self, predicates, node_map, logic, commands, list_of_node_ids):
+        for predicate in predicates:
+            predicate_type = predicate['type'].replace(" ", "_").lower()
+            source_node = node_map.get(predicate['source'])
+            target_node = node_map.get(predicate['target'])
+            
+            if not source_node or not target_node:
+                continue
+            
+            self._process_predicate_logic(source_node, target_node, predicate, predicate_type, logic, commands, list_of_node_ids)
+    
+    def _process_predicate_logic(self, source_node, target_node, predicate, predicate_type, logic, commands, list_of_node_ids):
+        source_var = source_node['node_id']
+        target_var = target_node['node_id']
+        list_of_node_ids.add(source_var)
+        list_of_node_ids.add(target_var)
+
+        if logic and predicate['predicate_id'] in commands['preds'][self.MATCH_NO_PRED_LABELS]:
+            self._add_match_return_no_predicates(source_var, target_var, predicate, commands)
+        else:
+            self._add_match_with_predicates(source_node, target_node, predicate, predicate_type, source_var, target_var, commands)
+    
+    def _add_match_return_no_predicates(self, source_var, target_var, predicate, commands):
+        commands['preds']['match'].append(f"({source_var})-[{predicate['predicate_id']}]->({target_var})")
+        commands['preds']['return'].append(predicate['predicate_id'])
+
+    def _add_match_with_predicates(self, source_node, target_node, predicate, predicate_type, source_var, target_var, commands):
+        source_match = self.match_node(source_node)
+        commands['preds']['where'].extend(self.where_construct(source_node))
+        commands['preds']['match'].append(source_match)
+        
+        target_match = self.match_node(target_node)
+        commands['preds']['where'].extend(self.where_construct(target_node))
+        commands['preds']['match'].append(f"({source_var})-[{predicate['predicate_id']}:{predicate_type}]->{target_match}")
+        commands['preds']['return'].append(predicate['predicate_id'])
+    
+    def construct_clause(self, query_clauses, limit):
+        match_clause = f"MATCH {', '.join(query_clauses['match_clause'])}"
+        return_clause = f"RETURN {', '.join(query_clauses['return_clause'])}"
+        
+        if query_clauses['where_clause']:
+            where_clause = f"WHERE {' AND '.join(query_clauses['where_clause'])}"
             return f"{match_clause} {where_clause} {return_clause} {self.limit_query(limit)}"
+        
         return f"{match_clause} {return_clause} {self.limit_query(limit)}"
 
     def construct_union_clause(self, query_clauses, limit):
-        match_no_clause = ''
-        where_no_clause = ''
-        return_count_no_preds_clause = ''
-        match_clause = ''
-        where_clause = ''
-        return_count_preds_clause = ''
-
-        # Check and construct clause for match with no predicates
-        if 'match_no_preds' in query_clauses and query_clauses['match_no_preds']:
-            match_no_clause = f"MATCH {', '.join(query_clauses['match_no_preds'])}"
-            if 'where_no_preds' in query_clauses and query_clauses['where_no_preds']:
-                where_no_clause = f"WHERE {' AND '.join(query_clauses['where_no_preds'])}"
-            return_count_no_preds_clause = "RETURN " + ', '.join(query_clauses['return_no_preds'])
-
-        # Construct a clause for match with predicates
-        if 'match_preds' in query_clauses and query_clauses['match_preds']:
-            match_clause = f"MATCH {', '.join(query_clauses['match_preds'])}"
-            if 'where_preds' in query_clauses and query_clauses['where_preds']:
-                where_clause = f"WHERE {' AND '.join(query_clauses['where_preds'])}"
-            return_count_preds_clause = "RETURN " + ', '.join(query_clauses['full_return_preds'])
-
-        clauses = {}
-
-        # Update the query_clauses dictionary with the constructed clauses
-        clauses['match_no_clause'] = match_no_clause
-        clauses['where_no_clause'] = where_no_clause
-        clauses['return_no_clause'] = return_count_no_preds_clause
-        clauses['match_clause'] = match_clause
-        clauses['where_clause'] = where_clause
-        clauses['return_clause'] = return_count_preds_clause
-        
+        clauses = self._construct_union_parts(query_clauses)
         query = self.construct_call_clause(clauses, limit)
         return query
 
+    def _construct_union_parts(self, query_clauses):
+        clauses = {}
+        
+        clauses['match_no_clause'] = self._get_clause_part('match_no_preds', query_clauses)
+        clauses['where_no_clause'] = self._get_clause_part('where_no_preds', query_clauses, 'AND')
+        clauses['return_no_clause'] = self._get_return_clause(query_clauses, 'return_no_preds')
+        
+        clauses['match_clause'] = self._get_clause_part('match_preds', query_clauses)
+        clauses['where_clause'] = self._get_clause_part('where_preds', query_clauses, 'AND')
+        clauses['return_clause'] = self._get_return_clause(query_clauses, 'full_return_preds')
+        
+        clauses['optional_match'], clauses['optional_where'], clauses['optional_return'], clauses['optional_with'] = self._process_optional_clauses(query_clauses)
+        
+        return clauses
+
+    def _get_clause_part(self, key, query_clauses, join_type=None):
+        if key in query_clauses and query_clauses[key]:
+            if join_type:
+                return f"{key.upper()} {' '.join(query_clauses[key])}"
+            return f"MATCH {', '.join(query_clauses[key])}"
+        return ''
+
+    def _get_return_clause(self, query_clauses, key):
+        if key in query_clauses:
+            return "RETURN " + ', '.join(query_clauses[key])
+        return ''
+
+    def _process_optional_clauses(self, query_clauses):
+        optional_match, optional_where, optional_return, optional_with = [], [], [], []
+        
+        if 'optional_match' in query_clauses and query_clauses['optional_match']:
+            for match in query_clauses['optional_match']:
+                optional_match.append(f"OPTIONAL MATCH {match}")
+            
+        if 'optional_where' in query_clauses and query_clauses['optional_where']:
+            for where in query_clauses['optional_where']:
+                optional_where.append(f"WHERE {where}")
+        
+        if 'optional_with' in query_clauses:
+            for with_clause in query_clauses['optional_with']:
+                optional_with.append(f"WITH {with_clause}")
+        
+        if 'optional_return' in query_clauses:
+            for return_clause in query_clauses['optional_return']:
+                optional_return.append(f"RETURN {', '.join(return_clause)}")
+        
+        return optional_match, optional_where, optional_return, optional_with
+    # Static or class variables for reusable strings
+    MATCH_TEMPLATE = "MATCH {}"
+    WHERE_TEMPLATE = "WHERE {}"
+    OPTIONAL_MATCH_TEMPLATE = "OPTIONAL MATCH {}"
+    WITH_TEMPLATE = "WITH {}"
+    RETURN_TEMPLATE = "RETURN {}"
+    COALESCE_LABELS = "COALESCE(labels({}), [])"
+
     def construct_count_clause(self, query_clauses):
-        match_no_clause = ''
-        where_no_clause = ''
-        match_clause = ''
-        where_clause = ''
-        return_preds = []
+        # Initialize variables
+        match_no_clause, where_no_clause, match_clause, where_clause = '', '', '', ''
+        return_preds, optional_returns, query = [], [], ''
+        
+        # Optional match clause
+        if 'optional_match' in query_clauses and query_clauses['optional_match']:
+            query = self.construct_optional_match(query_clauses)
 
         # Construct clause for match with no predicates
-        if 'match_no_preds' in query_clauses and query_clauses['match_no_preds']:
-            match_no_clause = f"MATCH {', '.join(query_clauses['match_no_preds'])}"
-            if 'where_no_preds' in query_clauses and query_clauses['where_no_preds']:
-                where_no_clause = f"WHERE {' AND '.join(query_clauses['where_no_preds'])}"
+        match_no_clause, where_no_clause = self.construct_match_no_preds(query_clauses)
 
         # Construct clause for match with predicates
-        if 'match_preds' in query_clauses and query_clauses['match_preds']:
-            match_clause = f"MATCH {', '.join(query_clauses['match_preds'])}"
-            if 'where_preds' in query_clauses and query_clauses['where_preds']:
-                where_clause = f"WHERE {' AND '.join(query_clauses['where_preds'])}"
+        match_clause, where_clause = self.construct_match_preds(query_clauses)
 
-        if "return_no_preds" in query_clauses and "return_preds" in query_clauses:
+        # Handle node returns
+        if "return_no_preds" in query_clauses:
             query_clauses['list_of_node_ids'].extend(query_clauses['return_no_preds'])
-
+        
+        # Handle predicates
         if "return_preds" in query_clauses:
             return_preds = query_clauses['return_preds']
+        
+        if 'optional_match' in query_clauses:
+            query_clauses['list_of_node_ids'].extend(optional_returns)
 
+        # Label clause construction
+        label_clause = self.construct_label_clause(query_clauses, return_preds)
+
+        # UNWIND label clause
+        unwind_label_clause = 'UNWIND all_labels AS label'
+
+        # Count clause for labels
+        count_clause = self.construct_count_label_clause(query_clauses, return_preds)
+
+        # Construct count by label
+        node_count_by_label = 'WITH COLLECT({label: label, count: node_count}) AS nodes_count_by_label'
+
+        # Additional clauses for relationships
+        if return_preds or 'optional_match' in query_clauses:
+            count_relationships, unwind_relationships, count_edge_by_label, return_clause = \
+                self.construct_relationship_clauses(query_clauses)
+            query = self.combine_query(
+                query, match_no_clause, where_no_clause, match_clause, where_clause, 
+                label_clause, unwind_label_clause, count_clause, node_count_by_label,
+                count_relationships, unwind_relationships, count_edge_by_label, return_clause
+            )
+        else:
+            count_edge_by_label = 'WITH nodes_count_by_label'
+            return_clause = (
+                'RETURN nodes_count_by_label, '
+                'REDUCE(total = 0, n IN nodes_count_by_label | total + n.count) AS total_nodes'
+            )
+            query = f'''
+            {match_no_clause}
+            {where_no_clause}
+            {match_clause}
+            {where_clause}
+            {label_clause}
+            {unwind_label_clause}
+            {count_clause}
+            {node_count_by_label}
+            {count_edge_by_label}
+            {return_clause}
+            '''
+        
+        print("QUERY : ", query)
+        return query
+
+    # Helper method to construct optional match clause
+    def construct_optional_match(self, query_clauses):
+        optional_match, optional_where, optional_return, optional_with = [], [], [], []
+        for match in query_clauses['optional_match']:
+            optional_match.append(f"OPTIONAL MATCH {match}")
+        if 'optional_where' in query_clauses and query_clauses['optional_where']:
+            for where in query_clauses['optional_where']:
+                optional_where.append(f"WHERE {where}")
+        for with_clause in query_clauses['optional_with']:
+            optional_with.append(f"WITH {with_clause}")
+        for return_clause in query_clauses['optional_return']:
+            #optional_returns.extend(return_clause)
+            optional_return.append(f"RETURN {', '.join(return_clause)}")
+        
+        return " ".join([
+            f'CALL() {{ {optional_with[i]} {optional_match[i]} {optional_where[i]} {optional_return[i]} }}'
+            for i in range(len(optional_match))
+        ])
+
+    # Helper method to construct match clause for no predicates
+    def construct_match_no_preds(self, query_clauses):
+        match_no_clause, where_no_clause = '', ''
+        if 'match_no_preds' in query_clauses and query_clauses['match_no_preds']:
+            match_no_clause = self.MATCH_TEMPLATE.format(', '.join(query_clauses['match_no_preds']))
+            if 'where_no_preds' in query_clauses and query_clauses['where_no_preds']:
+                where_no_clause = self.WHERE_TEMPLATE.format(' AND '.join(query_clauses['where_no_preds']))
+        return match_no_clause, where_no_clause
+
+    # Helper method to construct match clause for predicates
+    def construct_match_preds(self, query_clauses):
+        match_clause, where_clause = '', ''
+        if 'match_preds' in query_clauses and query_clauses['match_preds']:
+            match_clause = self.MATCH_TEMPLATE.format(', '.join(query_clauses['match_preds']))
+            if 'where_preds' in query_clauses and query_clauses['where_preds']:
+                where_clause = self.WHERE_TEMPLATE.format(' AND '.join(query_clauses['where_preds']))
+        return match_clause, where_clause
+
+    # Helper method to construct label clause
+    def construct_label_clause(self, query_clauses, return_preds):
+        predicate_ids = [predicate['predicate_id'] for predicate in query_clauses['predicates']]
         label_clause = (
             'WITH DISTINCT ' +
-            ' + '.join([f"labels({n})" for n in query_clauses['list_of_node_ids']]) +
+            ' + '.join([self.COALESCE_LABELS.format(n) for n in query_clauses['list_of_node_ids'] if n not in predicate_ids]) +
             ' AS all_labels'
         )
-
         if not return_preds:
             label_clause += ', ' + ', '.join(query_clauses['list_of_node_ids'])
         else:
             label_clause += ', ' + ', '.join(return_preds)
+        return label_clause
 
-        unwind_label_clause = 'UNWIND all_labels AS label'
-
+    # Helper method to construct count label clause
+    def construct_count_label_clause(self, query_clauses, return_preds):
         count_clause = []
-        if return_preds:
-            for index, predicate in enumerate(query_clauses['predicates']):
-                count_clause.append(f'WHEN label IN labels(startNode(r{index})) THEN startNode(r{index})')
-                count_clause.append(f'WHEN label IN labels(endNode(r{index})) THEN endNode(r{index})')
+        if return_preds or 'optional_match' in query_clauses:
+            for predicate in query_clauses['predicates']:
+                count_clause.append(f'WHEN label IN labels(startNode({predicate["predicate_id"]})) THEN startNode({predicate["predicate_id"]})')
+                count_clause.append(f'WHEN label IN labels(endNode({predicate["predicate_id"]})) THEN endNode({predicate["predicate_id"]})')
         else:
             for node_id in query_clauses['list_of_node_ids']:
                 count_clause.append(f'WHEN label IN labels({node_id}) THEN {node_id}')
-
         count_clause = ' '.join(count_clause)
-        count_clause = f'WITH label, count(DISTINCT CASE {count_clause} ELSE null END) AS node_count'
+        return f'WITH label, count(DISTINCT CASE {count_clause} ELSE null END) AS node_count'
 
-        node_count_by_label = 'WITH COLLECT({label: label, count: node_count}) AS nodes_count_by_label'
-
-        if return_preds:
-            count_relationships = (
+    # Helper method to construct relationship clauses
+    def construct_relationship_clauses(self, query_clauses):
+        count_relationships = (
             'WITH nodes_count_by_label, ' +
-            ' + '.join([f'COLLECT(DISTINCT r{i})' for i in range(len(query_clauses['predicates']))]) +
+            ' + '.join([f'COLLECT(DISTINCT {predicate["predicate_id"]})' for predicate in query_clauses['predicates']]) +
             ' AS relationships'
-            )
-            unwind_relationships = 'UNWIND relationships AS rel'
-            count_edge_by_label = (
+        )
+        unwind_relationships = 'UNWIND relationships AS rel'
+        count_edge_by_label = (
             'WITH nodes_count_by_label, TYPE(rel) AS relationship_type, COUNT(rel) AS edge_count '
             'WITH nodes_count_by_label, COLLECT(DISTINCT {relationship_type: relationship_type, count: edge_count}) AS edges_count_by_type'
-            )
-            return_clause = (
+        )
+        return count_relationships, unwind_relationships, count_edge_by_label, (
             'RETURN nodes_count_by_label, edges_count_by_type, '
             'REDUCE(total = 0, n IN nodes_count_by_label | total + n.count) AS total_nodes, '
             'REDUCE(total_edges = 0, e IN edges_count_by_type | total_edges + e.count) AS total_edges'
-            )
-            query = f'''
-            {match_no_clause}
-            {where_no_clause}
-            {match_clause}
-            {where_clause}
-            {label_clause}
-            {unwind_label_clause}
-            {count_clause}
-            {node_count_by_label}
-            {match_no_clause}
-            {where_no_clause}
-            {match_clause}
-            {where_clause}
-            {count_relationships}
-            {unwind_relationships}
-            {count_edge_by_label}
-            {return_clause}
-            '''
+        )
+
+    # Helper method to combine all query components
+    def combine_query(self, query, match_no_clause, where_no_clause, match_clause, where_clause, label_clause, unwind_label_clause,
+                      count_clause, node_count_by_label, count_relationships, unwind_relationships, count_edge_by_label, return_clause):
+        return f'''
+        {query}
+        {match_no_clause}
+        {where_no_clause}
+        {match_clause}
+        {where_clause}
+        {label_clause}
+        {unwind_label_clause}
+        {count_clause}
+        {node_count_by_label}
+        {match_no_clause}
+        {where_no_clause}
+        {match_clause}
+        {where_clause}
+        {count_relationships}
+        {unwind_relationships}
+        {count_edge_by_label}
+        {return_clause}
+        '''
+    
+    OR_TEMPLATE = " OR "
+    WHERE_TEMPLATE = "{}.{} = '{}'"
+
+    def construct_or_operation(self, logic, node_map, predicate_map, node_with_predicates, commands):
+        source, target = [], []
+        
+        # Handle nodes logic
+        if 'nodes' in logic:
+            where_clause = self.construct_node_where_clause(logic['nodes'], node_with_predicates, commands)
+        
+        # Handle predicates logic
+        if 'predicates' in logic:
+            commands, node_map = self.construct_predicate_operations(logic['predicates'], node_map, predicate_map, commands, source, target)
+
+        return commands, node_map
+
+    # Helper method to construct where clause for nodes
+    def construct_node_where_clause(self, nodes_logic, node_with_predicates, commands):
+        properties_or = []
+        where_clause = ''
+        
+        node_id = nodes_logic['node_id']
+        properties = nodes_logic['properties']
+
+        for property, value in properties.items():
+            for single_value in value:
+                properties_or.append(self.WHERE_TEMPLATE.format(node_id, property, single_value))
+        
+        where_clause = self.OR_TEMPLATE.join(properties_or)
+        
+        if node_id in node_with_predicates:
+            commands['preds']['where'].append(where_clause)
         else:
-            count_edge_by_label = 'WITH nodes_count_by_label'
-            return_clause = (
-            'RETURN nodes_count_by_label, '
-            'REDUCE(total = 0, n IN nodes_count_by_label | total + n.count) AS total_nodes'
-            )
-            query = f'''
-            {match_no_clause}
-            {where_no_clause}
-            {match_clause}
-            {where_clause}
-            {label_clause}
-            {unwind_label_clause}
-            {count_clause}
-            {node_count_by_label}
-            {match_no_clause}
-            {where_no_clause}
-            {match_clause}
-            {where_clause}
-            {count_edge_by_label}
-            {return_clause}
-            '''
+            commands['no_preds']['where'].append(where_clause)
 
-        return query
+        return where_clause
 
+    # Helper method to handle predicate operations
+    def construct_predicate_operations(self, predicate_ids, node_map, predicate_map, commands, source, target):
+        for predicate_id in predicate_ids:
+            optional_where = []
+            predicate = predicate_map[predicate_id]
+            source_node = node_map[predicate['source']]
+            target_node = node_map[predicate['target']]
+            predicate_type = predicate['type'].replace(" ", "_").lower()
+
+            source.append(source_node['node_id'])
+            target.append(target_node['node_id'])
+
+            # Construct match for source and target nodes
+            source_match = self.match_node(source_node, None, True, source_node['type'], target_node['type'])
+            target_match = self.match_node(target_node, None, True, source_node['type'], target_node['type'])
+
+            optional_match = f"{source_match}-[{predicate_id}:{predicate_type}]->{target_match}"
+
+            commands['preds']['optional_match'].append(optional_match)
+
+            # Construct where clauses
+            optional_where.extend(self.where_construct(source_node, None, source_node['type'], target_node['type']))
+            optional_where.extend(self.where_construct(target_node, None, source_node['type'], target_node['type']))
+
+            source_id = f'{source_node["type"]}_{source_node["node_id"]}_{target_node["type"]}'
+            target_id = f'{source_node["type"]}_{source_node["node_id"]}_{target_node["type"]}'
+
+            commands['preds']['optional_where'].append(f"{' AND '.join(optional_where)}")
+            commands['preds']['optional_return'].append([source_id, target_id, predicate_id])
+            commands['preds']['with'].append('true As always_true')
+
+        # Remove processed nodes from node_map
+        node_map = self.remove_processed_nodes(node_map, source, target)
+
+        return commands, node_map
+
+    # Helper method to remove processed nodes from node_map
+    def remove_processed_nodes(self, node_map, source, target):
+        for source_id in source:
+            if source_id in node_map:
+                node_map.pop(source_id)
+        for target_id in target:
+            if target_id in node_map:
+                node_map.pop(target_id)
+        return node_map
+
+    # Placeholder for match_node method
+    def match_node(self, source_node, target_node, optional, source_type, target_type):
+        # Add logic to match nodes here
+        return f"({source_node['node_id']}:{source_type})"
+
+    # Placeholder for where_construct method
+    def where_construct(self, source_node, target_node, source_type, target_type):
+        # Add logic to construct where clauses here
+        return [f"{source_node['node_id']}={target_node['node_id']}"]
+    
+    NOT_TEMPLATE = "NOT {}"
+    TYPE_TEMPLATE = "type({}) <> '{}'"
+
+    def construct_not_operation(self, logic, node_map, predicate_map, node_with_predicates, command):
+        if 'nodes' in logic:
+            command = self.handle_nodes_not_operation(logic['nodes'], node_map, node_with_predicates, command)
+        elif 'predicates' in logic:
+            command = self.handle_predicates_not_operation(logic['predicates'], predicate_map, command)
+
+        print("NOT COMMANDS: ", command)
+        return command
+
+    # Helper method to handle nodes in the NOT operation
+    def handle_nodes_not_operation(self, nodes_logic, node_map, node_with_predicates, command):
+        node_id = nodes_logic['node_id']
+        nodes = nodes_logic
+
+        if 'properties' in nodes:
+            where_clause = self.where_construct(nodes, "NOT")
+            if node_id in node_with_predicates:
+                command['preds']['where'].extend(where_clause)
+            else:
+                command['no_preds']['where'].extend(where_clause)
+        else:
+            node_type = node_map[node_id]['type']
+            where_clause = self.NOT_TEMPLATE.format(f"({node_id}: {node_type})")
+            if node_id in node_with_predicates:
+                command['preds']['no_node_labels'].add(node_id)
+                command['preds']['where'].append(where_clause)
+            else:
+                command['no_preds']['no_node_labels'].add(node_id)
+                command['no_preds']['where'].append(where_clause)
+
+        return command
+
+    # Helper method to handle predicates in the NOT operation
+    def handle_predicates_not_operation(self, predicates_logic, predicate_map, command):
+        predicate_id = predicates_logic['predicate_id']
+        predicate = predicate_map[predicate_id]
+        label = predicate['type'].replace(" ", "_").lower()
+
+        # Update labels and add predicate to the command
+        command['preds']['no_node_labels'].update([predicate['source'], predicate['target']])
+        command['preds']['no_predicate_labels'].add(predicate_id)
+
+        where_clause = self.TYPE_TEMPLATE.format(predicate_id, label)
+        command['preds']['where'].append(where_clause)
+
+        return command
+
+    # Placeholder for where_construct method
+    def where_construct(self, nodes_logic, operation_type):
+        # Logic for constructing where clauses
+        return [f"{operation_type} ({nodes_logic['node_id']}:{nodes_logic['type']})"]
+    
+    
 
     def limit_query(self, limit):
         if limit:
@@ -346,51 +649,95 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             curr_limit = 1000
         return f"LIMIT {curr_limit}"
 
+    def build_call_clause(self, match_clause, where_clause, return_clause, limit, is_count_sum):
+        limit_part = self.limit_query(limit) if not is_count_sum else ""
+        return f'CALL() {{ {match_clause} {where_clause} {return_clause} {limit_part} }}'
+
     def construct_call_clause(self, clauses, limit=None):
-        if not ("match_no_clause" in clauses or "match_clause" in clauses):
+        if not ("match_no_clause" in clauses or "match_clause" in clauses or 'optional_match' in clauses):
             raise Exception("Either 'match_clause' or 'match_no_clause' must be present")
 
-        # Build CALL clauses
+        # Initialize list to hold call clauses
         call_clauses = []
 
-        # For both nodes without predicate and with predicate
+        # Handle 'match_no_clause' if it exists
         if "match_no_clause" in clauses and clauses["match_no_clause"]:
             call_clauses.append(
-                f'CALL() {{ {clauses["match_no_clause"]} '
-                f'{clauses.get("where_no_clause", "")} '
-                f'{clauses["return_no_clause"]} '
-                f'{self.limit_query(limit) if "return_count_sum" not in clauses else ""} }}'
+                self.build_call_clause(
+                    clauses["match_no_clause"], 
+                    clauses.get("where_no_clause", ""), 
+                    clauses["return_no_clause"], 
+                    limit, 
+                    "return_count_sum" in clauses
+                )
             )
 
+        # Handle 'match_clause' if it exists
         if "match_clause" in clauses and clauses["match_clause"]:
             call_clauses.append(
-                f'CALL() {{ {clauses["match_clause"]} '
-                f'{clauses.get("where_clause", "")} '
-                f'{clauses["return_clause"]} '
-                f'{self.limit_query(limit) if "return_count_sum" not in clauses else ""} }}'
+                self.build_call_clause(
+                    clauses["match_clause"], 
+                    clauses.get("where_clause", ""), 
+                    clauses["return_clause"], 
+                    limit, 
+                    "return_count_sum" in clauses
+                )
             )
 
-        # Add any additional return clause sum/normal query
+        # Handle 'optional_match' if it exists
+        if "optional_match" in clauses and clauses["optional_match"]:
+            for i in range(len(clauses["optional_match"])):
+                call_clauses.append(
+                    self.build_call_clause(
+                        clauses["optional_match"][i], 
+                        clauses["optional_where"][i], 
+                        clauses["optional_return"][i], 
+                        limit, 
+                        "return_count_sum" in clauses
+                    )
+                )
+
+        # Final return clause (with or without count sum)
         final_clause = clauses.get("return_count_sum", "RETURN *")
         call_clauses.append(final_clause)
 
-        # Combine clauses into a single string
+        # Join all clauses into a single string
         return " ".join(call_clauses)
+    
+    # Placeholder for limit_query method
+    def limit_query(self, limit):
+        return f"LIMIT {limit}" if limit else ""
 
+    def match_node(self, node, no_label_ids=None, unique=False, source=None, target=None):
+        if no_label_ids and node['node_id'] in no_label_ids:
+            return f"({node['node_id']})"
 
-
-    def match_node(self, node, var_name):
         if node['id']:
-            return f"({var_name}:{node['type']} {{id: '{node['id']}'}})"
+            if unique:
+                return f"({source}_{node['node_id']}_{target}:{node['type']} {{id: '{node['id']}'}})"
+            return f"({node['node_id']}:{node['type']} {{id: '{node['id']}'}})"
         else:
-            return f"({var_name}:{node['type']})"
+            if unique:
+                return f"({source}_{node['node_id']}_{target}:{node['type']})"
+            return f"({node['node_id']}:{node['type']})"
 
-    def where_construct(self, node, var_name):
+    def where_construct(self, node, operation=None, source=None, target=None):
         properties = []
-        if node['id']: 
+        if 'id' in node and node['id']: 
             return properties
-        for key, property in node['properties'].items():
-            properties.append(f"{var_name}.{key} =~ '(?i){property}'")
+        
+        if operation == "NOT":
+            for key, property in node['properties'].items():
+                if source and target:
+                    properties.append(f"{source}_{node['node_id']}_{target}.{key} <> '{property}'")
+                else:
+                    properties.append(f"{node['node_id']}.{key} <> '{property}'")
+        else:
+            for key, property in node['properties'].items():
+                if source and target:
+                    properties.append(f"{source}_{node['node_id']}_{target}.{key} = '{property}'")
+                else:
+                    properties.append(f"{node['node_id']}.{key} =~ '(?i){property}'")
         return properties
 
     def parse_neo4j_results(self, results, all_properties):
@@ -408,90 +755,115 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         (_, _, node_dict, edge_dict, _) = self.process_result(results, True)
         return (node_dict, edge_dict)
 
-    def process_result(self, results, all_properties):
-        match_result = results[0]
-        if len(results) > 1:
-            count_result = results[1]
-        else:
-            count_result = None
-        node_count = 0
-        edge_count = 0
-        node_count_by_label = []
-        edge_count_by_label = []
-        nodes = []
-        edges = []
-        node_dict = {}
-        node_to_dict = {}
-        edge_to_dict = {}
-        node_type = set()
-        edge_type = set()
-        visited_relations = set()
+    def build_node_data(self,item, all_properties, named_types):
+        """
+        Builds the node data and returns both node ID and the corresponding node data structure.
+        """
+        node_id = f"{list(item.labels)[0]} {item['id']}"
+        node_data = {"data": {"id": node_id, "type": list(item.labels)[0]}}
 
+        for key, value in item.items():
+            if all_properties:
+                if key != "id" and key != "synonyms":
+                    node_data["data"][key] = value
+            else:
+                if key in named_types:
+                    node_data["data"]["name"] = value
+        if "name" not in node_data["data"]:
+            node_data["data"]["name"] = node_id
+        
+        return node_id, node_data
+
+
+    def build_edge_data(self,item, visited_relations):
+        """
+        Builds the edge data while avoiding duplicates, and returns the edge data.
+        """
+        source_label = list(item.start_node.labels)[0]
+        target_label = list(item.end_node.labels)[0]
+        source_id = f"{source_label} {item.start_node['id']}"
+        target_id = f"{target_label} {item.end_node['id']}"
+        
+        # Avoid duplicate edges
+        temp_relation_id = f"{source_id} - {item.type} - {target_id}"
+        if temp_relation_id in visited_relations:
+            return None
+        visited_relations.add(temp_relation_id)
+
+        edge_data = {"data": {
+            "id": f"{source_label}_{item.type}_{target_label}",
+            "label": item.type,
+            "source": source_id,
+            "target": target_id
+        }}
+
+        for key, value in item.items():
+            if key == 'source':
+                edge_data["data"]["source_data"] = value
+            else:
+                edge_data["data"][key] = value
+
+        return edge_data
+
+
+    def process_result(self,results, all_properties):
+        """
+        Processes the result to build nodes and edges while counting and categorizing them.
+        """
+        match_result = results[0]
+        count_result = results[1] if len(results) > 1 else None
+        
+        node_count, edge_count = 0, 0
+        node_count_by_label, edge_count_by_label = [], []
+        nodes, edges = [], []
+        node_dict, node_to_dict, edge_to_dict = {}, {}, {}
+        node_type, edge_type, visited_relations = set(), set(), set()
+
+        # Named types for properties
         named_types = ['gene_name', 'transcript_name', 'protein_name', 'pathway_name', 'term_name']
 
         for record in match_result:
-            for item in record.values():
-                if isinstance(item, neo4j.graph.Node):
-                    node_id = f"{list(item.labels)[0]} {item['id']}"
-                    if node_id not in node_dict:
-                        node_data = {
-                            "data": {
-                                "id": node_id,
-                                "type": list(item.labels)[0],
-                            }
-                        }
-
-                        for key, value in item.items():
-                            if all_properties:
-                                if key != "id" and key != "synonyms":
-                                    node_data["data"][key] = value
-                            else:
-                                if key in named_types:
-                                    node_data["data"]["name"] = value
-                        if "name" not in node_data["data"]:
-                            node_data["data"]["name"] = node_id
+            for key, item in record.items():
+                if item is None:
+                    continue
+                elif isinstance(item, list):
+                    for sub_item in item:
+                        node_id, node_data = self.build_node_data(sub_item, all_properties, named_types)
                         nodes.append(node_data)
+                        node_dict[node_id] = node_data
                         if node_data["data"]["type"] not in node_type:
                             node_type.add(node_data["data"]["type"])
-                            node_to_dict[node_data['data']['type']] = []
-                        node_to_dict[node_data['data']['type']].append(node_data)
-                        node_dict[node_id] = node_data
-                elif isinstance(item, neo4j.graph.Relationship):
-                    source_label = list(item.start_node.labels)[0]
-                    target_label = list(item.end_node.labels)[0]
-                    source_id = f"{list(item.start_node.labels)[0]} {item.start_node['id']}"
-                    target_id = f"{list(item.end_node.labels)[0]} {item.end_node['id']}"
-                    edge_data = {
-                        "data": {
-                            # "id": item.id,
-                            "edge_id": f"{source_label}_{item.type}_{target_label}",
-                            "label": item.type,
-                            "source": source_id,
-                            "target": target_id,
-                        }
-                    }
-                    temp_relation_id = f"{source_id} - {item.type} - {target_id}"
-                    if temp_relation_id in visited_relations:
-                        continue
-                    visited_relations.add(temp_relation_id)
-
-                    for key, value in item.items():
-                        if key == 'source':
-                            edge_data["data"]["source_data"] = value
+                            node_to_dict[node_data['data']['type']] = [node_data]
                         else:
-                            edge_data["data"][key] = value
-                    edges.append(edge_data)
-                    if edge_data["data"]["label"] not in edge_type:
-                        edge_type.add(edge_data["data"]["label"])
-                        edge_to_dict[edge_data['data']['label']] = []
-                    edge_to_dict[edge_data['data']['label']].append(edge_data)
+                            node_to_dict[node_data['data']['type']].append(node_data)
 
+                elif isinstance(item, neo4j.graph.Node):
+                    node_id, node_data = self.build_node_data(item, all_properties, named_types)
+                    nodes.append(node_data)
+                    node_dict[node_id] = node_data
+                    if node_data["data"]["type"] not in node_type:
+                        node_type.add(node_data["data"]["type"])
+                        node_to_dict[node_data['data']['type']] = [node_data]
+                    else:
+                        node_to_dict[node_data['data']['type']].append(node_data)
+
+                elif isinstance(item, neo4j.graph.Relationship):
+                    edge_data = self.build_edge_data(item, visited_relations)
+                    if edge_data:
+                        edges.append(edge_data)
+                        if edge_data["data"]["label"] not in edge_type:
+                            edge_type.add(edge_data["data"]["label"])
+                            edge_to_dict[edge_data['data']['label']] = [edge_data]
+                        else:
+                            edge_to_dict[edge_data['data']['label']].append(edge_data)
+
+        # Process counts if available
         if count_result:
-            for count_record in count_result:
-                node_count_by_label = count_record['nodes_count_by_label']
-                edge_count_by_label = count_record.get('edges_count_by_type', [])
-                node_count = count_record['total_nodes']
-                edge_count = count_record.get('total_edges', 0)
+            count_record = count_result[0]
+            node_count_by_label = count_record['nodes_count_by_label']
+            edge_count_by_label = count_record.get('edges_count_by_type', [])
+            node_count = count_record['total_nodes']
+            edge_count = count_record.get('total_edges', 0)
 
         meta_data = {
             "node_count": node_count,
@@ -499,22 +871,28 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             "node_count_by_label": node_count_by_label,
             "edge_count_by_label": edge_count_by_label
         }
-    
-        return (nodes, edges, node_to_dict, edge_to_dict, meta_data)
+        
+        return nodes, edges, node_to_dict, edge_to_dict, meta_data
 
-    def parse_id(self, request):
+
+    def parse_id(self,request):
+        """
+        Parses and modifies node IDs in the request, especially for named types.
+        """
         nodes = request["nodes"]
         named_types = {"gene": "gene_name", "transcript": "transcript_name"}
         prefixes = ["ensg", "enst"]
- 
+
         for node in nodes:
             is_named_type = node['type'] in named_types
             id = node["id"].lower()
             is_name_as_id = all(not id.startswith(prefix) for prefix in prefixes)
             no_id = node["id"] != ''
+
             if is_named_type and is_name_as_id and no_id:
                 node_type = named_types[node['type']]
                 node['properties'][node_type] = node["id"]
-                node['id'] = ''
-            node["id"] = node["id"].lower()
+                node['id'] = ''  # Reset the ID to empty
+            node["id"] = node["id"].lower()  # Convert ID to lowercase
+
         return request

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -464,7 +464,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                     edge_data = {
                         "data": {
                             # "id": item.id,
-                            "id": f"{source_label}_{item.type}_{target_label}",
+                            "edge_id": f"{source_label}_{item.type}_{target_label}",
                             "label": item.type,
                             "source": source_id,
                             "target": target_id,

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -56,7 +56,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
 
         logger.info(f"Finished loading {len(nodes_paths)} nodes and {len(edges_paths)} edges datasets.")
 
-    def run_query(self, query_code, source):
+    def run_query(self, query_code, source=None):
         results = []
         if isinstance(query_code, list):
             find_query = query_code[0]

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -350,8 +350,8 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             count_result = results[1]
         else:
             count_result = None
-        node_count = None
-        edge_count = None
+        node_count = 0
+        edge_count = 0
         nodes = []
         edges = []
         node_dict = {}

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -254,8 +254,9 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             return_preds = query_clauses['return_preds']
         query = ''
 
-        lable_clause = 'WITH ' + f"{f"lables{n}" for n in query_clauses['list_of_node_ids']}"
+        label_clause = 'WITH ' + ' + '.join([f"labels({n})" for n in query_clauses['list_of_node_ids']])
 
+        unwind_label_clause = 'UNWIND all_labels AS label'
         return query
 
 

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -457,11 +457,14 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                         node_to_dict[node_data['data']['type']].append(node_data)
                         node_dict[node_id] = node_data
                 elif isinstance(item, neo4j.graph.Relationship):
+                    source_label = list(item.start_node.labels)[0]
+                    target_label = list(item.end_node.labels)[0]
                     source_id = f"{list(item.start_node.labels)[0]} {item.start_node['id']}"
                     target_id = f"{list(item.end_node.labels)[0]} {item.end_node['id']}"
                     edge_data = {
                         "data": {
                             # "id": item.id,
+                            "label_id": f"{source_label}-{item.type}-{target_label}",
                             "label": item.type,
                             "source": source_id,
                             "target": target_id,

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -67,10 +67,13 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         
         with self.driver.session() as session:
             results.append(list(session.run(find_query)))
-
         if count_query:
-            with self.driver.session() as session:
-                results.append(list(session.run(count_query)))
+            try:
+                with self.driver.session() as session:
+                    results.append(list(session.run(count_query)))
+            except:
+                results.append([])
+                return results
 
         return results
 

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -56,7 +56,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
 
         logger.info(f"Finished loading {len(nodes_paths)} nodes and {len(edges_paths)} edges datasets.")
 
-    def run_query(self, query_code):
+    def run_query(self, query_code, source):
         results = []
         if isinstance(query_code, list):
             find_query = query_code[0]
@@ -67,7 +67,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
         
         with self.driver.session() as session:
             results.append(list(session.run(find_query)))
-        if count_query:
+        if count_query and source != 'hypotehesis':
             try:
                 with self.driver.session() as session:
                     results.append(list(session.run(count_query)))

--- a/app/services/graph_handler.py
+++ b/app/services/graph_handler.py
@@ -141,6 +141,7 @@ class Graph_Summarizer:
 
     def summary(self,graph,user_query=None,graph_id=None, summary=None):
         prev_summery=[]
+        response = None
         try:
 
             if graph_id:

--- a/app/services/llm_handler.py
+++ b/app/services/llm_handler.py
@@ -30,4 +30,5 @@ class LLMHandler:
     def generate_summary(self, graph, user_query=None,graph_id=None, summary=None):
         summarizer = Graph_Summarizer(self.model)
         summary = summarizer.summary(graph, user_query, graph_id, summary)
+        print("Summary",summary)
         return summary

--- a/config/schema_config.yaml
+++ b/config/schema_config.yaml
@@ -674,7 +674,7 @@ super enhancer to gene association:
   represented_as: edge
   input_label: super_enhancer_gene
   output_label: associated_with
-  source: super enhancer
+  source: super_enhancer
   target: gene
   properties:
     score: float

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pytest == 8.3.3
 gunicorn == 23.0.0
 Flask-Limiter == 3.8.0 
 tiktoken==0.8.0
+httpx==0.27.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,9 @@ gunicorn == 23.0.0
 Flask-Limiter == 3.8.0 
 tiktoken==0.8.0
 httpx==0.27.2
+ 
+flask-socketio
+gevent
+gevent-websocket
+flask-cors
+cors

--- a/run.py
+++ b/run.py
@@ -1,12 +1,13 @@
-from app import app
+from app import app, socketio
 from dotenv import load_dotenv
 import os
 
+# Load environment variables from .env file
 load_dotenv()
 
-APP_PORT = os.getenv('APP_PORT')
+# Fetch the application port from environment variables
+APP_PORT = os.getenv('APP_PORT', 5000)  # Default to 5000 if APP_PORT is not set
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=APP_PORT)
-    
-    
+    # Run the Flask application with SocketIO support
+    socketio.run(app, debug=True, host='0.0.0.0', port=int(APP_PORT))


### PR DESCRIPTION
This pull request introduces a mechanism to replace the numeric value in the LIMIT clause of queries with a placeholder before saving them to MongoDB. This ensures that queries differing only by the LIMIT value (e.g., LIMIT 100 vs. LIMIT 1000) are treated as identical when checking for existing queries in the database.

Changes Implemented:
Replaced the numeric value in the LIMIT clause with a placeholder before saving the query to the storage collection in MongoDB.
Updated the get_user_query method to check queries for equality, ignoring the numeric value in the LIMIT clause.
Tested the changes by:
Manipulating the LIMIT value in Postman (e.g., 100, 1000).
Confirming that duplicate entries are no longer saved in the database.
Verifying in mongosh that the query is saved only once, regardless of the LIMIT value.
Benefits:
Prevents duplicate entries in the database when queries differ only by the LIMIT value.
Reduces storage redundancy and ensures consistent behavior when querying for existing entries. 