### PR TITLE
feat: Redis query deduplication with signature-based single-flight

### DIFF
--- a/app/annotation_controller.py
+++ b/app/annotation_controller.py
@@ -5,7 +5,14 @@ import json
 import os
 import threading
 import datetime
-from app.workers.task_handler import generate_result, start_thread, reset_task, reset_status
+from app.workers.task_handler import (
+    generate_result,
+    start_thread,
+    reset_task,
+    reset_status,
+    start_dedup_replication,
+)
+from app.lib.query_dedup import resolve as resolve_query_dedup
 from app.lib import convert_to_csv, generate_file_path, \
     adjust_file_path
 import time
@@ -14,6 +21,22 @@ from app.persistence import AnnotationStorageService
 
 llm = app.config['llm_handler']
 EXP = os.getenv('REDIS_EXPIRATION', 3600) # expiration time of redis cache
+
+
+def _start_query_work(annotation_id, args, query, request, species, data_source):
+    mode, leader_id = resolve_query_dedup(
+        annotation_id,
+        query,
+        request,
+        species,
+        data_source,
+        app.config.get('db_type', 'cypher'),
+    )
+    if mode in ('follower', 'cache') and leader_id:
+        start_dedup_replication(annotation_id, leader_id, args, mode)
+    else:
+        start_thread(annotation_id, args)
+
 
 def handle_client_request(query, request, current_user_id, node_types, species, data_source):
     annotation_id = request.get('annotation_id', None)
@@ -48,7 +71,7 @@ def handle_client_request(query, request, current_user_id, node_types, species, 
                                'label_count_done': label_count_done}, 'query': query, 'request': request,
                 'summary': summary, 'meta_data': meta_data, 'data_source': data_source, 'species': species}
 
-        start_thread(annotation_id, args)
+        _start_query_work(annotation_id, args, query, request, species, data_source)
         return Response(
             json.dumps({"annotation_id": str(annotation_id)}),
             mimetype='application/json')
@@ -65,7 +88,7 @@ def handle_client_request(query, request, current_user_id, node_types, species, 
         args = {'all_status': {'result_done': result_done, 'total_count_done': total_count_done,
                                'label_count_done': label_count_done}, 'query': query, 'request': request,
                 'summary': None, 'meta_data': None, 'data_source': data_source, 'species': species}
-        start_thread(annotation_id, args)
+        _start_query_work(annotation_id, args, query, request, species, data_source)
 
         return Response(
             json.dumps({"annotation_id": str(annotation_id)}),
@@ -85,9 +108,9 @@ def handle_client_request(query, request, current_user_id, node_types, species, 
 
         args = {'all_status': {'result_done': result_done, 'total_count_done': total_count_done,
                                'label_count_done': label_count_done}, 'query': query, 'request': request,
-                'summary': None, 'meta_data': None, 'species': species}
+                'summary': None, 'meta_data': None, 'species': species, 'data_source': data_source}
 
-        start_thread(annotation_id, args)
+        _start_query_work(annotation_id, args, query, request, species, data_source)
 
         return Response(
             json.dumps({'annotation_id': str(annotation_id)}),

--- a/app/lib/query_dedup.py
+++ b/app/lib/query_dedup.py
@@ -1,0 +1,176 @@
+"""
+Signature-based query deduplication using Redis: single-flight for concurrent
+identical queries and a short-lived result pointer for recent completions.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from typing import Any, Optional, Tuple
+
+from app import redis_client
+from app.constants import TaskStatus
+
+_LOG = logging.getLogger(__name__)
+
+PREFIX = "qdedup"
+EXP = int(os.getenv("REDIS_EXPIRATION", "3600"))
+ACTIVE_TTL = int(os.getenv("QUERY_DEDUP_ACTIVE_TTL", "7200"))
+
+
+def is_enabled() -> bool:
+    return os.getenv("QUERY_DEDUP_ENABLED", "true").lower() in ("1", "true", "yes")
+
+
+def _decode(val: Any) -> str:
+    if val is None:
+        return ""
+    if isinstance(val, bytes):
+        return val.decode("utf-8", errors="replace")
+    return str(val)
+
+
+def _structural_request(request: dict) -> dict:
+    """Identity for the graph query: ignore annotation_id and incidental fields."""
+    nodes = request.get("nodes") or []
+    predicates = request.get("predicates") or []
+    return {"nodes": nodes, "predicates": predicates}
+
+
+def compute_signature(
+    query: Tuple[str, str, str],
+    request: dict,
+    species: str,
+    data_source: str,
+    db_type: str,
+) -> str:
+    payload = {
+        "db": db_type,
+        "q0": query[0],
+        "q1": query[1],
+        "q2": query[2],
+        "species": species or "human",
+        "data_source": data_source or "all",
+        "req": _structural_request(request),
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _cache_still_valid(ref_id: str) -> bool:
+    raw = redis_client.get(str(ref_id))
+    if not raw:
+        return False
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return False
+    if data.get("status") != TaskStatus.COMPLETE.value:
+        return False
+    g = data.get("graph")
+    return g is not None
+
+
+def resolve(
+    annotation_id,
+    query: Tuple[str, str, str],
+    request: dict,
+    species: str,
+    data_source: str,
+    db_type: str,
+) -> Tuple[str, Optional[str]]:
+    """
+    Decide how this annotation should obtain results.
+
+    Returns:
+        ("disabled", None) — run normal pipeline
+        ("leader", None) — this task executes the DB queries
+        ("follower", leader_id) — wait for leader and replicate
+        ("cache", ref_id) — replicate from a recent completed annotation (no DB)
+    """
+    if not is_enabled():
+        return ("disabled", None)
+
+    sig = compute_signature(query, request, species, data_source, db_type)
+    active_key = f"{PREFIX}:active:{sig}"
+    aid = str(annotation_id)
+
+    # In-flight leader must win over a stale result_ref, or followers would
+    # attach to an old completed annotation while a new run is executing.
+    leader_raw = redis_client.get(active_key)
+    leader_id = _decode(leader_raw) if leader_raw else ""
+    if leader_id and leader_id != aid:
+        followers_key = f"{PREFIX}:followers:{sig}"
+        redis_client.sadd(followers_key, aid)
+        redis_client.expire(followers_key, ACTIVE_TTL)
+        redis_client.setex(f"{PREFIX}:sig_for:{aid}", ACTIVE_TTL, sig)
+        return ("follower", leader_id)
+
+    # Warm path: no in-flight leader; reuse recent identical result if Redis still holds it.
+    ref_key = f"{PREFIX}:result_ref:{sig}"
+    cached = redis_client.get(ref_key)
+    if cached:
+        ref_id = _decode(cached)
+        if ref_id and _cache_still_valid(ref_id):
+            return ("cache", ref_id)
+        redis_client.delete(ref_key)
+
+    if redis_client.set(active_key, aid, nx=True, ex=ACTIVE_TTL):
+        redis_client.setex(f"{PREFIX}:sig_for:{aid}", ACTIVE_TTL, sig)
+        return ("leader", None)
+
+    leader_raw = redis_client.get(active_key)
+    leader_id = _decode(leader_raw) if leader_raw else ""
+    if leader_id and leader_id != aid:
+        followers_key = f"{PREFIX}:followers:{sig}"
+        redis_client.sadd(followers_key, aid)
+        redis_client.expire(followers_key, ACTIVE_TTL)
+        redis_client.setex(f"{PREFIX}:sig_for:{aid}", ACTIVE_TTL, sig)
+        return ("follower", leader_id)
+
+    if redis_client.set(active_key, aid, nx=True, ex=ACTIVE_TTL):
+        redis_client.setex(f"{PREFIX}:sig_for:{aid}", ACTIVE_TTL, sig)
+        return ("leader", None)
+
+    _LOG.warning("query_dedup: ambiguous leader race for sig=%s; claiming active slot", sig[:12])
+    redis_client.set(active_key, aid, ex=ACTIVE_TTL)
+    redis_client.setex(f"{PREFIX}:sig_for:{aid}", ACTIVE_TTL, sig)
+    return ("leader", None)
+
+
+def notify_leader_ended(annotation_id, status: str) -> None:
+    """
+    Release single-flight lock and optionally register result pointer for cache hits.
+    Call when a dedup leader reaches a terminal state (COMPLETE, FAILED, CANCELLED).
+    """
+    if not is_enabled():
+        return
+
+    aid = str(annotation_id)
+    sig_raw = redis_client.get(f"{PREFIX}:sig_for:{aid}")
+    if not sig_raw:
+        return
+
+    sig = _decode(sig_raw)
+    # Publish result pointer before releasing the active lock so concurrent
+    # requests never see neither active nor result_ref (which would start a duplicate run).
+    if status == TaskStatus.COMPLETE.value:
+        redis_client.setex(f"{PREFIX}:result_ref:{sig}", EXP, aid)
+    redis_client.delete(f"{PREFIX}:active:{sig}")
+    redis_client.delete(f"{PREFIX}:sig_for:{aid}")
+
+
+def cleanup_follower(annotation_id) -> None:
+    """Remove follower from the waiting set after replication or timeout."""
+    if not is_enabled():
+        return
+
+    aid = str(annotation_id)
+    sig_raw = redis_client.get(f"{PREFIX}:sig_for:{aid}")
+    if not sig_raw:
+        return
+    sig = _decode(sig_raw)
+    redis_client.srem(f"{PREFIX}:followers:{sig}", aid)
+    redis_client.delete(f"{PREFIX}:sig_for:{aid}")

--- a/app/workers/task_handler.py
+++ b/app/workers/task_handler.py
@@ -3,16 +3,29 @@ from app import app, schema_manager, db_instance, socketio, redis_client, Thread
 import logging
 import json
 import os
+import shutil
 import threading
 import time
 from app.lib import Graph
+from app.lib import query_dedup
 from app.constants import TaskStatus
 from app.persistence import AnnotationStorageService
 from pathlib import Path
 import traceback
 
 llm = app.config['llm_handler']
-EXP = os.getenv('REDIS_EXPIRATION', 3600) # expiration time of redis cache
+EXP = int(os.getenv('REDIS_EXPIRATION') or 3600)  # expiration time of redis cache
+DEDUP_WAIT_TIMEOUT = float(os.getenv('QUERY_DEDUP_WAIT_TIMEOUT', '7200'))
+
+GRAPH_DIR = Path(__file__).resolve().parent.parent.parent / 'public' / 'graph'
+
+
+def _notify_dedup_leader(annotation_id, status: str):
+    try:
+        query_dedup.notify_leader_ended(annotation_id, status)
+    except Exception as e:
+        logging.error('query_dedup leader notify failed: %s', e)
+
 
 def update_task(annotation_id, graph=None):
     with app.config['annotation_lock']:
@@ -31,6 +44,7 @@ def update_task(annotation_id, graph=None):
             }))
             AnnotationStorageService.update(annotation_id, {'status': status})
             redis_client.delete(f"{annotation_id}_tasks")
+            _notify_dedup_leader(annotation_id, TaskStatus.COMPLETE.value)
             return TaskStatus.COMPLETE.value
 
         # Increment task count atomically and get the new count
@@ -38,6 +52,7 @@ def update_task(annotation_id, graph=None):
 
         if status in [TaskStatus.FAILED.value, TaskStatus.CANCELLED.value]:
             if task_num >= 4 and cache['status'] == TaskStatus.CANCELLED.value:
+                _notify_dedup_leader(annotation_id, TaskStatus.CANCELLED.value)
                 AnnotationStorageService.delete(annotation_id)
                 redis_client.delete(f"{annotation_id}_tasks")
                 redis_client.delete(str(annotation_id))
@@ -52,6 +67,7 @@ def update_task(annotation_id, graph=None):
             }))
             AnnotationStorageService.update(annotation_id, {'status': status})
             redis_client.delete(f"{annotation_id}_tasks")
+            _notify_dedup_leader(annotation_id, status)
         elif status == TaskStatus.PENDING.value:
             redis_client.set(str(annotation_id), json.dumps({
                 'graph': graph, 'status': status
@@ -221,6 +237,7 @@ def generate_result(query_code, annotation_id, requests, result_status, species,
         socketio.emit('update', {'status': TaskStatus.FAILED.value, 'update': {'graph': False}})
         AnnotationStorageService.update(annotation_id, {'status': TaskStatus.FAILED.value})
         result_status.set()
+        _notify_dedup_leader(annotation_id, TaskStatus.FAILED.value)
         logging.error("Error generating result graph %s", e)
 
 
@@ -382,6 +399,7 @@ def generate_total_count(
             },
         )
         total_count_status.set()
+        _notify_dedup_leader(annotation_id, TaskStatus.FAILED.value)
         logging.error("Error generating total count %s", e)
         traceback.print_exc()
 
@@ -535,7 +553,7 @@ def generate_label_count(
         count_label_status.set()
         logging.error("Error generating result graph %s", e)
     except Exception as e:
-        set_status(annotation_id, "FAILED")
+        set_status(annotation_id, TaskStatus.FAILED.value)
         update_task(annotation_id)
 
         update = generate_empty_lable_count(requests)
@@ -549,8 +567,203 @@ def generate_label_count(
         )
         socketio.emit("update", {"status": TaskStatus.FAILED.value, "update": update})
         count_label_status.set()
+        _notify_dedup_leader(annotation_id, TaskStatus.FAILED.value)
         logging.error("Error generating label count %s", e)
         traceback.print_exc()
+
+
+def replicate_annotation_from_leader(follower_id, leader_id):
+    leader_doc = AnnotationStorageService.get_by_id(leader_id)
+    if not leader_doc:
+        raise ValueError('leader annotation not found')
+    cache = get_annotation_redis(leader_id)
+    if not cache:
+        raise ValueError('leader redis cache missing')
+    graph = cache.get('graph')
+    if graph is None:
+        raise ValueError('leader graph not ready')
+
+    src = GRAPH_DIR / f'{leader_id}.json'
+    dst = GRAPH_DIR / f'{follower_id}.json'
+    GRAPH_DIR.mkdir(parents=True, exist_ok=True)
+    if src.exists():
+        shutil.copy2(src, dst)
+    path_url = str(dst.resolve()) if dst.exists() else getattr(leader_doc, 'path_url', None)
+
+    AnnotationStorageService.update(
+        follower_id,
+        {
+            'status': TaskStatus.COMPLETE.value,
+            'node_count': leader_doc.node_count,
+            'edge_count': leader_doc.edge_count,
+            'node_count_by_label': leader_doc.node_count_by_label,
+            'edge_count_by_label': leader_doc.edge_count_by_label,
+            'summary': leader_doc.summary,
+            'path_url': path_url,
+        },
+    )
+
+    redis_client.setex(
+        str(follower_id),
+        EXP,
+        json.dumps({'graph': graph, 'status': TaskStatus.COMPLETE.value}),
+    )
+    redis_client.delete(f'{follower_id}_tasks')
+
+    socketio.emit(
+        'update',
+        {'status': TaskStatus.COMPLETE.value, 'update': {'graph': True}},
+        to=str(follower_id),
+    )
+    socketio.emit(
+        'update',
+        {
+            'status': TaskStatus.COMPLETE.value,
+            'update': {
+                'node_count': leader_doc.node_count,
+                'edge_count': leader_doc.edge_count,
+            },
+        },
+        to=str(follower_id),
+    )
+    socketio.emit(
+        'update',
+        {
+            'status': TaskStatus.COMPLETE.value,
+            'update': {
+                'node_count_by_label': leader_doc.node_count_by_label,
+                'edge_count_by_label': leader_doc.edge_count_by_label,
+            },
+        },
+        to=str(follower_id),
+    )
+    if leader_doc.summary:
+        socketio.emit(
+            'update',
+            {'status': TaskStatus.COMPLETE.value, 'update': {'summary': leader_doc.summary}},
+            to=str(follower_id),
+        )
+
+
+def replicate_leader_terminal_to_follower(follower_id, leader_id, status: str):
+    leader_doc = AnnotationStorageService.get_by_id(leader_id)
+    payload = {'status': status}
+    if leader_doc:
+        payload['node_count'] = getattr(leader_doc, 'node_count', None)
+        payload['edge_count'] = getattr(leader_doc, 'edge_count', None)
+        payload['node_count_by_label'] = getattr(leader_doc, 'node_count_by_label', None)
+        payload['edge_count_by_label'] = getattr(leader_doc, 'edge_count_by_label', None)
+    else:
+        payload['node_count'] = 0
+        payload['edge_count'] = 0
+
+    AnnotationStorageService.update(follower_id, payload)
+    set_status(follower_id, status)
+    if status == TaskStatus.FAILED.value:
+        socketio.emit(
+            'update',
+            {'status': status, 'update': {'graph': False}},
+            to=str(follower_id),
+        )
+    elif status == TaskStatus.CANCELLED.value:
+        socketio.emit(
+            'update',
+            {'status': status, 'update': {'graph': False}},
+            to=str(follower_id),
+        )
+
+
+def _try_replicate_from_leader(follower_id, leader_id) -> bool:
+    cache = get_annotation_redis(leader_id)
+    if not cache:
+        return False
+    if cache.get('status') != TaskStatus.COMPLETE.value:
+        return False
+    if cache.get('graph') is None:
+        return False
+    replicate_annotation_from_leader(follower_id, leader_id)
+    return True
+
+
+def wait_and_replicate_dedup(follower_id, leader_id, args, mode: str):
+    annotation_threads = app.config['annotation_threads']
+    annotation_threads[str(follower_id)] = threading.Event()
+
+    if mode == 'cache':
+        if _try_replicate_from_leader(follower_id, leader_id):
+            return
+        logging.warning(
+            'query_dedup cache miss for follower=%s leader=%s; running full pipeline',
+            follower_id,
+            leader_id,
+        )
+        start_thread(follower_id, args)
+        return
+
+    deadline = time.time() + DEDUP_WAIT_TIMEOUT
+    while time.time() < deadline:
+        leader_status = get_status(leader_id)
+        if leader_status == TaskStatus.COMPLETE.value:
+            cache = get_annotation_redis(leader_id)
+            if cache and cache.get('graph') is not None:
+                replicate_annotation_from_leader(follower_id, leader_id)
+                query_dedup.cleanup_follower(follower_id)
+                return
+        elif leader_status == TaskStatus.FAILED.value:
+            replicate_leader_terminal_to_follower(
+                follower_id, leader_id, TaskStatus.FAILED.value
+            )
+            query_dedup.cleanup_follower(follower_id)
+            return
+        elif leader_status == TaskStatus.CANCELLED.value:
+            replicate_leader_terminal_to_follower(
+                follower_id, leader_id, TaskStatus.CANCELLED.value
+            )
+            query_dedup.cleanup_follower(follower_id)
+            return
+        time.sleep(0.25)
+
+    logging.error(
+        'query_dedup follower=%s timed out waiting for leader=%s',
+        follower_id,
+        leader_id,
+    )
+    AnnotationStorageService.update(
+        follower_id, {'status': TaskStatus.FAILED.value, 'node_count': 0, 'edge_count': 0}
+    )
+    set_status(follower_id, TaskStatus.FAILED.value)
+    socketio.emit(
+        'update',
+        {'status': TaskStatus.FAILED.value, 'update': {'graph': False}},
+        to=str(follower_id),
+    )
+    query_dedup.cleanup_follower(follower_id)
+
+
+def start_dedup_replication(annotation_id, leader_id, args, mode: str):
+    def run():
+        try:
+            wait_and_replicate_dedup(annotation_id, leader_id, args, mode)
+        except Exception as e:
+            logging.exception('query_dedup replication failed: %s', e)
+            try:
+                AnnotationStorageService.update(
+                    annotation_id, {'status': TaskStatus.FAILED.value}
+                )
+                set_status(annotation_id, TaskStatus.FAILED.value)
+                socketio.emit(
+                    'update',
+                    {'status': TaskStatus.FAILED.value, 'update': {'graph': False}},
+                    to=str(annotation_id),
+                )
+            except Exception:
+                logging.exception('query_dedup follower failure cleanup failed')
+            query_dedup.cleanup_follower(annotation_id)
+
+    threading.Thread(
+        name=f'query_dedup_{annotation_id}', target=run, daemon=True
+    ).start()
+
 
 def start_thread(annotation_id, args):
     all_status = args['all_status']

--- a/tests/unit/test_query_dedup.py
+++ b/tests/unit/test_query_dedup.py
@@ -1,0 +1,84 @@
+"""Unit tests for signature-based query deduplication (Redis layer)."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+QUERY = ("MATCH (n) RETURN n LIMIT 1", "COUNT 1", "COUNT 2")
+REQ = {"nodes": [{"id": "a", "type": "Gene", "node_id": "x"}], "predicates": []}
+
+
+def test_compute_signature_stable():
+    from app.lib.query_dedup import compute_signature
+
+    s1 = compute_signature(QUERY, REQ, "human", "all", "cypher")
+    s2 = compute_signature(QUERY, REQ, "human", "all", "cypher")
+    assert s1 == s2
+    assert len(s1) == 64
+
+
+def test_compute_signature_differs_by_species():
+    from app.lib.query_dedup import compute_signature
+
+    a = compute_signature(QUERY, REQ, "human", "all", "cypher")
+    b = compute_signature(QUERY, REQ, "fly", "all", "cypher")
+    assert a != b
+
+
+def test_resolve_leader_on_first_acquire():
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = None
+    mock_redis.set.return_value = True  # NX wins
+
+    with patch("app.lib.query_dedup.redis_client", mock_redis):
+        from app.lib import query_dedup
+
+        with patch.object(query_dedup, "is_enabled", return_value=True):
+            mode, leader = query_dedup.resolve(
+                "ann1", QUERY, REQ, "human", "all", "cypher"
+            )
+    assert mode == "leader"
+    assert leader is None
+    mock_redis.set.assert_called()
+
+
+def test_resolve_follower_when_active_exists():
+    mock_redis = MagicMock()
+    # First GET is qdedup:active:{sig} — another annotation holds the lock
+    mock_redis.get.side_effect = [b"leader99"]
+    mock_redis.set.return_value = False
+
+    with patch("app.lib.query_dedup.redis_client", mock_redis):
+        from app.lib import query_dedup
+
+        with patch.object(query_dedup, "is_enabled", return_value=True):
+            mode, leader = query_dedup.resolve(
+                "ann2", QUERY, REQ, "human", "all", "cypher"
+            )
+    assert mode == "follower"
+    assert leader == "leader99"
+
+
+def test_resolve_disabled():
+    from app.lib import query_dedup
+
+    with patch.object(query_dedup, "is_enabled", return_value=False):
+        mode, leader = query_dedup.resolve(
+            "ann1", QUERY, REQ, "human", "all", "cypher"
+        )
+    assert mode == "disabled"
+    assert leader is None
+
+
+def test_notify_leader_releases_active_and_sets_result_ref():
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = b"abc_sig_hex"
+
+    with patch("app.lib.query_dedup.redis_client", mock_redis):
+        from app.lib import query_dedup
+        from app.constants import TaskStatus
+
+        with patch.object(query_dedup, "is_enabled", return_value=True):
+            query_dedup.notify_leader_ended("ann1", TaskStatus.COMPLETE.value)
+
+    mock_redis.delete.assert_any_call(f"{query_dedup.PREFIX}:active:abc_sig_hex")
+    mock_redis.setex.assert_called()


### PR DESCRIPTION
- Add app/lib/query_dedup.py: SHA-256 signature, resolve(), leader notify, follower cleanup
- Route async queries via _start_query_work in annotation_controller
- Replicate leader results to followers/cache path in task_handler
- Add tests/unit/test_query_dedup.py

