### PR TITLE
refactor: unify graph result formatting across Neo4j, MeTTa, and Mork backends

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,7 +30,7 @@ logging.getLogger('werkzeug').disabled = True
 socketio = SocketIO(app, cors_allowed_origins='*',
                     async_mode='threading', logger=False, engineio_logger=False)
 
-app.config['REDIS_URL'] = os.getenv('REDIS_URL')
+app.config['REDIS_URL'] = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
 
 # intialize redis
 redis_client = FlaskRedis(app)

--- a/app/lib/result_formatter.py
+++ b/app/lib/result_formatter.py
@@ -201,3 +201,50 @@ class Result_Formatter:
             "edges": [{"data": edge} for edge in edges],
         }
 
+    def _process_count(self, data: Any, format_type: str, graph_components: Dict[str, Any]) -> ProcessedCount:
+        """Routes count processing to the appropriate database-specific handler."""
+        if format_type == "neo4j":
+            return self._process_neo4j_count(data, graph_components)
+        elif format_type in ["mork", "metta"]:
+            return self._process_metta_mork_count(data)
+
+        raise ValueError(f"Unknown format_type for count processing: {format_type}")
+
+    def _process_neo4j_count(self, results: Any, graph_components: Dict[str, Any]) -> ProcessedCount:
+        """Aggregates node and edge counts from Neo4j query results."""
+        if not results:
+            return {}
+
+        node_and_edge_count = results[0]
+        count_by_label = results[1] if len(results) > 1 else {}
+
+        node_count = node_and_edge_count.get('total_nodes', 0)
+        edge_count = node_and_edge_count.get('total_edges', 0)
+
+        node_agg = {n['type']: 0 for n in graph_components.get('nodes', [])}
+        edge_agg = {p['type'].replace(" ", "_").lower(): 0 for p in graph_components.get('predicates', [])}
+
+        for key, value in count_by_label.items():
+            label_key = '_'.join(key.split('_')[1:])
+            if label_key in node_agg:
+                node_agg[label_key] += value
+            if label_key in edge_agg:
+                edge_agg[label_key] += value
+
+        return {
+            "node_count": node_count,
+            "edge_count": edge_count,
+            "node_count_by_label": [{'label': k, 'count': v} for k, v in node_agg.items()],
+            "edge_count_by_label": [{'label': k, 'count': v} for k, v in edge_agg.items()],
+        }
+
+    def _process_metta_mork_count(self, results: Any) -> ProcessedCount:
+        """Aggregates node and edge counts from MeTTa/Mork query results."""
+        from app.services.mork import get_total_counts, get_count_by_label
+
+        meta_data = {}
+        if results and results[0]:
+            meta_data.update(get_total_counts(results[0]))
+        if len(results) > 1 and results[1]:
+            meta_data.update(get_count_by_label(results[1]))
+        return meta_data

--- a/app/lib/result_formatter.py
+++ b/app/lib/result_formatter.py
@@ -142,3 +142,54 @@ class Result_Formatter:
                     edges.append(edge_data)
 
         return nodes, edges
+
+    def _process_metta_graph(self, tuples: List[Tuple], graph_components: Dict[str, Any]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """Extracts nodes and edges from serialized MeTTa/Mork tuples."""
+        nodes_map = {}
+        rels_map = {}
+
+        properties_enabled = graph_components.get('properties', True)
+
+        for match in tuples:
+            graph_attr = match[0]
+            parts = match[1:]
+
+            if graph_attr == "node":
+                prop = parts[0]
+                src_type = parts[1]
+                src_value = parts[2]
+                target_val = parts[3:]
+
+                node_id = f"{src_type} {src_value}"
+
+                if node_id not in nodes_map:
+                    nodes_map[node_id] = {"id": node_id, "type": src_type}
+
+                if properties_enabled:
+                    nodes_map[node_id][prop] = target_val
+                elif prop in self.NAMED_TYPES:
+                    nodes_map[node_id]['name'] = target_val
+
+                nodes_map[node_id].pop('synonyms', None)
+
+            elif graph_attr == "edge":
+                prop = parts[0]
+                label = parts[1]
+                src_type = parts[2]
+                src_id = parts[3]
+                tgt_type = parts[4]
+                tgt_id = parts[5]
+                val = ' '.join(parts[6:])
+
+                rel_key = (label, src_type, src_id, tgt_type, tgt_id)
+                if rel_key not in rels_map:
+                    rels_map[rel_key] = {
+                        "edge_id": f"{src_type}_{label}_{tgt_type}",
+                        "label": label,
+                        "source": f"{src_type} {src_id}",
+                        "target": f"{tgt_type} {tgt_id}",
+                    }
+
+                rels_map[rel_key]["source_data" if prop == "source" else prop] = val
+
+        return list(nodes_map.values()), list(rels_map.values())

--- a/app/lib/result_formatter.py
+++ b/app/lib/result_formatter.py
@@ -1,22 +1,84 @@
+"""
+Unified Result Formatter
+
+This module centralizes the processing and formatting of query results from
+various database backends (Neo4j, MeTTa, Mork) into a unified JSON structure
+suitable for the frontend graph visualization.
+"""
+
+from typing import TypedDict, List, Dict, Any, Tuple, Union
+
+class LabelCount(TypedDict):
+    label: str
+    count: int
+
+class ProcessedCount(TypedDict):
+    node_count: int
+    edge_count: int
+    node_count_by_label: List[LabelCount]
+    edge_count_by_label: List[LabelCount]
+
+class NodeData(TypedDict):
+    data: Dict[str, Any]
+
+class EdgeData(TypedDict):
+    data: Dict[str, Any]
+
+class UnifiedGraphOutput(TypedDict):
+    nodes: List[NodeData]
+    edges: List[EdgeData]
+
 
 class Result_Formatter:
-    # Step-1: define the data input and output formats of all three of them
-    raw_data_format = {
-        "neo4j": {
-            "input": "",
-            "output": ""
-        },
-        "mork": {
-            "input": "",
-            "output": ""
-        },
-        "metta": {
-            "input": "",
-            "output": ""
-        },
-    }
+    """
+    Formats raw database results into a standardized graph or count representation.
+    """
 
-    normalized_data_format = {
-        "input": "",
-        "output": ""
-    }
+    NAMED_TYPES = [
+        'gene_name', 'transcript_name', 'protein_name',
+        'pathway_name', 'term_name'
+    ]
+
+    def format_result(self, data: Any, format_type: str, graph_components: Dict[str, Any], result_type: str = 'graph') -> Union[UnifiedGraphOutput, ProcessedCount, Dict[str, Any]]:
+        """
+        Main entry point for formatting database results.
+        
+        Args:
+            data: Raw results from the database.
+            format_type (str): The source database type ('neo4j', 'metta', 'mork').
+            graph_components (dict): Metadata about the requested graph structure.
+            result_type (str): The desired output format ('graph' or 'count').
+            
+        Returns:
+            dict: The formatted result in the unified structure.
+        """
+        if result_type == 'graph':
+            nodes, edges = self._process_graph(data, format_type, graph_components)
+            return self._format_graph_output(nodes, edges)
+
+        elif result_type == 'count':
+            return self._process_count(data, format_type, graph_components)
+
+        return {}
+
+    def _process_graph(self, data: Any, format_type: str, graph_components: Dict[str, Any]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """Routes graph processing to the appropriate database-specific handler."""
+        if format_type == "neo4j":
+            return self._process_neo4j_graph(data, graph_components)
+
+        elif format_type in ["mork", "metta"]:
+            from app.services.metta.metta_seralizer import metta_seralizer
+
+            results = data
+            identifiers = None
+            if isinstance(data, tuple) and len(data) == 2:
+                results, identifiers = data
+
+            tuples = metta_seralizer(results[0]) if isinstance(results, list) and results else []
+
+            if not tuples and identifiers:
+                return self._process_simple_graph(identifiers)
+
+            return self._process_metta_graph(tuples, graph_components)
+
+        raise ValueError(f"Unknown format_type for graph processing: {format_type}")

--- a/app/lib/result_formatter.py
+++ b/app/lib/result_formatter.py
@@ -82,3 +82,63 @@ class Result_Formatter:
             return self._process_metta_graph(tuples, graph_components)
 
         raise ValueError(f"Unknown format_type for graph processing: {format_type}")
+
+    def _process_neo4j_graph(self, results: Any, graph_components: Dict[str, Any]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """Extracts nodes and edges from Neo4j records."""
+        import neo4j
+
+        nodes = []
+        node_seen = {}
+        edges = []
+        edge_seen = set()
+
+        properties_enabled = graph_components.get('properties', True)
+
+        for record in results:
+            for item in record.values():
+                if isinstance(item, neo4j.graph.Node):
+                    label = list(item.labels)[0]
+                    node_id = f"{label} {item['id']}"
+
+                    if node_id in node_seen:
+                        continue
+
+                    node_data = {"id": node_id, "type": label}
+
+                    for key, value in item.items():
+                        if properties_enabled:
+                            if key not in ["id", "synonyms"]:
+                                node_data[key] = value
+                        elif key in self.NAMED_TYPES:
+                            node_data["name"] = value
+
+                    if "name" not in node_data:
+                        node_data["name"] = node_id
+
+                    nodes.append(node_data)
+                    node_seen[node_id] = node_data
+
+                elif isinstance(item, neo4j.graph.Relationship):
+                    source_label = list(item.start_node.labels)[0]
+                    target_label = list(item.end_node.labels)[0]
+                    source_id = f"{source_label} {item.start_node['id']}"
+                    target_id = f"{target_label} {item.end_node['id']}"
+
+                    rel_sig = f"{source_id} - {item.type} - {target_id}"
+                    if rel_sig in edge_seen:
+                        continue
+                    edge_seen.add(rel_sig)
+
+                    edge_data = {
+                        "edge_id": f"{source_label}_{item.type}_{target_label}",
+                        "label": item.type,
+                        "source": source_id,
+                        "target": target_id,
+                    }
+                    
+                    for key, value in item.items():
+                        edge_data["source_data" if key == 'source' else key] = value
+
+                    edges.append(edge_data)
+
+        return nodes, edges

--- a/app/lib/result_formatter.py
+++ b/app/lib/result_formatter.py
@@ -193,3 +193,11 @@ class Result_Formatter:
                 rels_map[rel_key]["source_data" if prop == "source" else prop] = val
 
         return list(nodes_map.values()), list(rels_map.values())
+
+    def _format_graph_output(self, nodes: List[Dict[str, Any]], edges: List[Dict[str, Any]]) -> UnifiedGraphOutput:
+        """Wraps standard node and edge dictionaries into the final unified format."""
+        return {
+            "nodes": [{"data": node} for node in nodes],
+            "edges": [{"data": edge} for edge in edges],
+        }
+

--- a/app/lib/result_formatter.py
+++ b/app/lib/result_formatter.py
@@ -248,3 +248,41 @@ class Result_Formatter:
         if len(results) > 1 and results[1]:
             meta_data.update(get_count_by_label(results[1]))
         return meta_data
+
+    def _process_simple_graph(self, results: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """
+        Creates a basic graph structure from identifiers when property fetching yields no results.
+        """
+        nodes_seen = set()
+        nodes = []
+        edges = []
+
+        for result in results:
+            if not result:
+                continue
+
+            source = result.get('source')
+            target = result.get('target')
+            predicate = result.get('predicate')
+
+            for node_id in [source, target]:
+                if node_id and node_id not in nodes_seen:
+                    nodes_seen.add(node_id)
+                    nodes.append({
+                        "id": node_id,
+                        "type": node_id.split(' ')[0],
+                        "name": node_id
+                    })
+
+            if source and target and predicate:
+                source_label = source.split(' ')[0]
+                target_label = target.split(' ')[0]
+                edges.append({
+                    "id": f"{source_label}_{predicate}_{target_label}_{len(edges)}",
+                    "edge_id": f"{source_label}_{predicate}_{target_label}",
+                    "label": predicate,
+                    "source": source,
+                    "target": target,
+                })
+
+        return nodes, edges

--- a/app/lib/result_formatter.py
+++ b/app/lib/result_formatter.py
@@ -1,0 +1,22 @@
+
+class Result_Formatter:
+    # Step-1: define the data input and output formats of all three of them
+    raw_data_format = {
+        "neo4j": {
+            "input": "",
+            "output": ""
+        },
+        "mork": {
+            "input": "",
+            "output": ""
+        },
+        "metta": {
+            "input": "",
+            "output": ""
+        },
+    }
+
+    normalized_data_format = {
+        "input": "",
+        "output": ""
+    }

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -8,7 +8,6 @@ import glob
 import os
 from neo4j.graph import Node, Relationship
 from app.error import ThreadStopException
-from app.lib.result_formatter import Result_Formatter
 
 load_dotenv()
 
@@ -27,6 +26,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             os.getenv('FLY_NEO4J_URI'),
             auth=(os.getenv('FLY_NEO4J_USERNAME'), os.getenv('FLY_NEO4J_PASSWORD'))
         )
+        from app.lib.result_formatter import Result_Formatter
         self.formatter = Result_Formatter()
         # self.dataset_path = dataset_path
         # self.load_dataset(self.dataset_path)

--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -8,6 +8,7 @@ import glob
 import os
 from neo4j.graph import Node, Relationship
 from app.error import ThreadStopException
+from app.lib.result_formatter import Result_Formatter
 
 load_dotenv()
 
@@ -26,6 +27,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             os.getenv('FLY_NEO4J_URI'),
             auth=(os.getenv('FLY_NEO4J_USERNAME'), os.getenv('FLY_NEO4J_PASSWORD'))
         )
+        self.formatter = Result_Formatter()
         # self.dataset_path = dataset_path
         # self.load_dataset(self.dataset_path)
 
@@ -336,179 +338,13 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                 properties.append(f"{var_name}.{key} =~ '(?i){property}'")
         return properties
 
-    def parse_neo4j_results(self, results, graph_components, result_type):
-        (nodes, edges, _, _, meta_data) = self.process_result(
-            results, graph_components, result_type)
-        return {"nodes": nodes, "edges": edges,
-                "node_count": meta_data.get('node_count', 0),
-                "edge_count": meta_data.get('edge_count', 0),
-                "node_count_by_label": meta_data.get('node_count_by_label', []),
-                "edge_count_by_label": meta_data.get('edge_count_by_label', [])
-                }
-
     def parse_and_serialize(self, input, schema, graph_components, result_type):
-        parsed_result = self.parse_neo4j_results(
-            input, graph_components, result_type)
-        return parsed_result
+        return self.formatter.format_result(input, "neo4j", graph_components, result_type)
 
     def convert_to_dict(self, results, schema, graph_components):
         graph_components['properties'] = True
-        (_, _, node_dict, edge_dict, _) = self.process_result(
-            results, graph_components)
-        return (node_dict, edge_dict)
-
-    def process_result_graph(self, results, graph_components):
-        node_dict = {}
-        visited_relations = set()
-        nodes = []
-        edges = []
-        node_dict = {}
-        node_to_dict = {}
-        edge_to_dict = {}
-        node_type = set()
-        edge_type = set()
-
-        named_types = ['gene_name', 'transcript_name',
-                       'protein_name', 'pathway_name', 'term_name']
-        for record in results:
-            for item in record.values():
-                if isinstance(item, neo4j.graph.Node):
-                    node_id = f"{list(item.labels)[0]} {item['id']}"
-                    if node_id not in node_dict:
-                        node_data = {
-                            "data": {
-                                "id": node_id,
-                                "type": list(item.labels)[0],
-                            }
-                        }
-
-                        for key, value in item.items():
-                            if graph_components['properties']:
-                                if key != "id" and key != "synonyms":
-                                    node_data["data"][key] = value
-                            else:
-                                if key in named_types:
-                                    node_data["data"]["name"] = value
-                        if "name" not in node_data["data"]:
-                            node_data["data"]["name"] = node_id
-                        nodes.append(node_data)
-                        if node_data["data"]["type"] not in node_type:
-                            node_type.add(node_data["data"]["type"])
-                            node_to_dict[node_data['data']['type']] = []
-                        node_to_dict[node_data['data']
-                                     ['type']].append(node_data)
-                        node_dict[node_id] = node_data
-                elif isinstance(item, neo4j.graph.Relationship):
-                    source_label = list(item.start_node.labels)[0]
-                    target_label = list(item.end_node.labels)[0]
-                    source_id = f"{list(item.start_node.labels)[0]} {item.start_node['id']}"
-                    target_id = f"{list(item.end_node.labels)[0]} {item.end_node['id']}"
-                    edge_data = {
-                        "data": {
-                            # "id": item.id,
-                            "edge_id": f"{source_label}_{item.type}_{target_label}",
-                            "label": item.type,
-                            "source": source_id,
-                            "target": target_id,
-                        }
-                    }
-                    temp_relation_id = f"{source_id} - {item.type} - {target_id}"
-                    if temp_relation_id in visited_relations:
-                        continue
-                    visited_relations.add(temp_relation_id)
-
-                    for key, value in item.items():
-                        if key == 'source':
-                            edge_data["data"]["source_data"] = value
-                        else:
-                            edge_data["data"][key] = value
-                    edges.append(edge_data)
-                    if edge_data["data"]["label"] not in edge_type:
-                        edge_type.add(edge_data["data"]["label"])
-                        edge_to_dict[edge_data['data']['label']] = []
-                    edge_to_dict[edge_data['data']
-                                 ['label']].append(edge_data)
-
-        return (nodes, edges, node_to_dict, edge_to_dict)
-
-    def process_result_count(self, node_and_edge_count, count_by_label, graph_components):
-        node_count_by_label = []
-        edge_count_by_label = []
-        node_count = 0
-        edge_count = 0
-
-        node_count += node_and_edge_count.get('total_nodes', 0)
-        edge_count += node_and_edge_count.get('total_edges', 0)
-        # build edge type set
-        node_count_aggregate = {}
-        ege_count_aggregate = {}
-
-        if len(count_by_label) != 0:
-            # initialize node count aggreate dictionary where the key is the label.
-            for node in graph_components['nodes']:
-                node_type = node['type']
-                node_count_aggregate[node_type] = {'count': 0}
-
-            # initialize edge count aggreate dictionary where the key is the label.
-            for predicate in graph_components['predicates']:
-                edge_type = predicate['type'].replace(" ", "_").lower()
-                ege_count_aggregate[edge_type] = {'count': 0}
-
-            # update node count aggregate dictionary with the count of each label
-            for key, value in count_by_label.items():
-                node_type_key = '_'.join(key.split('_')[1:])
-                if node_type_key in node_count_aggregate:
-                    node_count_aggregate[node_type_key]['count'] += value
-
-            # update edge count aggregate dictionary with the count of each label
-            for key, value in count_by_label.items():
-                edge_type_key = '_'.join(key.split('_')[1:])
-                if edge_type_key in ege_count_aggregate:
-                    ege_count_aggregate[edge_type_key]['count'] += value
-
-            # update the way node count by label and edge count by label are represented
-            for key, value in node_count_aggregate.items():
-                node_count_by_label.append(
-                    {'label': key, 'count': value['count']})
-
-            for key, value in ege_count_aggregate.items():
-                edge_count_by_label.append(
-                    {'label': key, 'count': value['count']})
-
-        meta_data = {
-            "node_count": node_count,
-            "edge_count": edge_count,
-            "node_count_by_label": node_count_by_label,
-            "edge_count_by_label": edge_count_by_label
-        }
-
-        return meta_data
-
-    def process_result(self, results, graph_components, result_type):
-        match_result = results
-        node_and_edge_count = {}
-        count_by_label = {}
-        nodes = []
-        edges = []
-        node_to_dict = {}
-        edge_to_dict = {}
-        meta_data = {}
-
-        if len(results) > 0:
-            node_and_edge_count = results[0]
-
-        if len(results) > 1:
-            count_by_label = results[1]
-
-        if result_type == 'graph':
-            nodes, edges, node_to_dict, edge_to_dict = self.process_result_graph(
-                match_result, graph_components)
-
-        if result_type == 'count':
-            meta_data = self.process_result_count(
-                node_and_edge_count, count_by_label, graph_components)
-
-        return (nodes, edges, node_to_dict, edge_to_dict, meta_data)
+        res = self.formatter.format_result(results, "neo4j", graph_components, result_type='graph')
+        return (res['nodes'], res['edges'])
 
     def parse_id(self, request):
         nodes = request["nodes"]

--- a/app/services/metta_generator.py
+++ b/app/services/metta_generator.py
@@ -4,7 +4,6 @@ from hyperon import MeTTa, SymbolAtom, ExpressionAtom, GroundedAtom
 import logging
 from .query_generator_interface import QueryGeneratorInterface
 from .metta import Metta_Ground, metta_seralizer
-from app.lib.result_formatter import Result_Formatter
 
 # Set up logging configuration
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -16,6 +15,7 @@ class MeTTa_Query_Generator(QueryGeneratorInterface):
         self.dataset_path = dataset_path
         self.load_dataset(self.dataset_path)
         self.initialize_grounatoms()
+        from app.lib.result_formatter import Result_Formatter
         self.formatter = Result_Formatter()
 
     def initialize_space(self):

--- a/app/services/metta_generator.py
+++ b/app/services/metta_generator.py
@@ -4,6 +4,8 @@ from hyperon import MeTTa, SymbolAtom, ExpressionAtom, GroundedAtom
 import logging
 from .query_generator_interface import QueryGeneratorInterface
 from .metta import Metta_Ground, metta_seralizer
+from app.lib.result_formatter import Result_Formatter
+
 # Set up logging configuration
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
@@ -14,6 +16,7 @@ class MeTTa_Query_Generator(QueryGeneratorInterface):
         self.dataset_path = dataset_path
         self.load_dataset(self.dataset_path)
         self.initialize_grounatoms()
+        self.formatter = Result_Formatter()
 
     def initialize_space(self):
         self.metta.run("!(bind! &space (new-space))")
@@ -189,198 +192,13 @@ class MeTTa_Query_Generator(QueryGeneratorInterface):
 
     def parse_and_serialize(self, input, schema, graph_components, result_type):
         if result_type == 'graph':
-
-            result = self.prepare_query_input(input, schema)
-            
-            result = self.parse_and_serialize_properties(result, graph_components, result_type)
-            return result
-        else:
-            (_,_,_,_, meta_data) = self.process_result(input, graph_components, result_type)
-            return {
-                "node_count": meta_data.get('node_count', 0),
-                "edge_count": meta_data.get('edge_count', 0),
-                "node_count_by_label": meta_data.get('node_count_by_label', []),
-                "edge_count_by_label": meta_data.get('edge_count_by_label', []),
-            }
+            input = self.prepare_query_input(input, schema) # Now returns (results, identifiers)
+        return self.formatter.format_result(input, "metta", graph_components, result_type)
         
-    def parse_and_serialize_properties(self, input, graph_components, result_type):
-        (nodes, edges, _, _, meta_data) = self.process_result(input, graph_components, result_type)
-        return {"nodes": nodes[0], "edges": edges[0],
-                "node_count": meta_data.get('node_count', 0),
-                "edge_count": meta_data.get('edge_count', 0),
-                "node_count_by_label": meta_data.get('node_count_by_label', []),
-                "edge_count_by_label": meta_data.get('edge_count_by_label', [])
-        }
-
-    def get_node_properties(self, results, schema):
-        metta = ('''!(match &space (,''')
-        output = (''' (,''') 
-        nodes = set()
-        for result in results:
-            source = result['source']
-            source_node_type = result['source'].split(' ')[0]
-
-            if source not in nodes:
-                for property, _ in schema[source_node_type]['properties'].items():
-                    id = self.generate_id()
-                    metta += " " + f'({property} ({source}) ${id})'
-                    output += " " + f'(node {property} ({source}) ${id})'
-                nodes.add(source)
-
-            if "target" in result and "predicate" in result:
-                target = result['target']
-                target_node_type = result['target'].split(' ')[0]
-                if target not in nodes:
-                    for property, _ in schema[target_node_type]['properties'].items():
-                        id = self.generate_id()
-                        metta += " " + f'({property} ({target}) ${id})'
-                        output += " " + f'(node {property} ({target}) ${id})'
-                    nodes.add(target)
-
-                predicate = result['predicate']
-                predicate_schema = f'{source_node_type}_{predicate}_{target_node_type}'
-                for property, _ in schema[predicate_schema]['properties'].items():
-                    random = self.generate_id()
-                    metta += " " + f'({property} ({predicate} ({source}) ({target})) ${random})'
-                    output +=  " " + f'(edge {property} ({predicate} ({source}) ({target})) ${random})' 
-
-        metta+= f" ) {output}))"
-        return metta
-
     def convert_to_dict(self, results, schema=None):
         result = self.prepare_query_input(results, schema)
-        (_, node_dict, edge_dict) = self.process_result(result[0], True)
-        return (node_dict, edge_dict)
-
-    # Won't work because of we don't try to parse node count and count by labels
-    def process_result(self, results, graph_components, result_type):
-        node_and_edge_count = {}
-        count_by_label = {}
-        nodes = []
-        edges = []
-        node_to_dict = {}
-        edge_to_dict = {}
-        meta_data = {}
-
-        if result_type == 'graph':
-            nodes, edges, node_to_dict, edge_to_dict = self.process_result_graph(
-                    results[0], graph_components)
-
-        if result_type == 'count':
-            if len(results) > 0:
-                node_and_edge_count = results[0]
-
-            if len(results) > 1:
-                count_by_label = results[1]
-
-            meta_data = self.process_result_count(
-                node_and_edge_count, count_by_label, graph_components)
-
-        return (nodes, edges, node_to_dict, edge_to_dict, meta_data)
-        
-    def process_result_graph(self, results, graph_components):
-        nodes = {}
-        relationships_dict = {}
-        node_result = []
-        edge_result = []
-        node_to_dict = {}
-        edge_to_dict = {}
-        node_type = set()
-        edge_type = set()
-        tuples = metta_seralizer(results)
-        named_types = ['gene_name', 'transcript_name', 'protein_name',
-                       'pathway_name', 'term_name']
-
-        for match in tuples:
-            graph_attribute = match[0]
-            match = match[1:]
-
-            if graph_attribute == "node":
-                if len(match) > 4:
-                    predicate = match[0]
-                    src_type = match[1]
-                    src_value = match[2]
-                    tgt = list(match[3:])
-                else:
-                    predicate, src_type, src_value, tgt = match
-                if (src_type, src_value) not in nodes:
-                    nodes[(src_type, src_value)] = {
-                        "id": f"{src_type} {src_value}",
-                        "type": src_type,
-                    }
-                
-                if graph_components['properties']:
-                     nodes[(src_type, src_value)][predicate] = tgt
-                else:
-                    if predicate in named_types:
-                        nodes[(src_type, src_value)]['name'] = tgt
-
-                if 'synonyms' in nodes[(src_type, src_value)]:
-                    del nodes[(src_type, src_value)]['synonyms']
-                if src_type not in node_type:
-                    node_type.add(src_type)
-                    node_to_dict[src_type] = []
-                node_data = {}
-                node_data["data"] = nodes[(src_type, src_value)]
-                node_to_dict[src_type].append(node_data)
-            elif graph_attribute == "edge":
-                property_name, predicate, source, source_id, target, target_id = match[:6]
-                value = ' '.join(match[6:])
-
-                key = (predicate, source, source_id, target, target_id)
-                if key not in relationships_dict:
-                    relationships_dict[key] = {
-                        "edge_id": f'{source}_{predicate}_{target}',
-                        "label": predicate,
-                        "source": f"{source} {source_id}",
-                        "target": f"{target} {target_id}",
-                    }
-                
-                if property_name == "source":
-                    relationships_dict[key]["source_data"] = value
-                else:
-                    relationships_dict[key][property_name] = value
-                
-                if predicate not in edge_type:
-                    edge_type.add(predicate)
-                    edge_to_dict[predicate] = []
-                edge_data = {}
-                edge_data['data'] = relationships_dict[key]
-                edge_to_dict[predicate].append(edge_data)
-        node_list = [{"data": node} for node in nodes.values()]
-        relationship_list = [{"data": relationship} for relationship in relationships_dict.values()]
-
-        node_result.append(node_list)
-        edge_result.append(relationship_list)
-        return (node_result, edge_result, node_to_dict, edge_to_dict)
-    
-    def process_result_count(self, node_and_edge_count, count_by_label, graph_components):
-        if len(node_and_edge_count) != 0:
-            node_and_edge_count = node_and_edge_count[0].get_object().value
-        node_count_by_label = []
-        edge_count_by_label = []
-        
-        if len(count_by_label) != 0:
-            count_by_label = count_by_label[0].get_object().value
-            node_label_count = count_by_label['node_label_count']
-            edge_label_count = count_by_label['edge_label_count']
-
-            # update the way node count by label and edge count by label are represented
-            for key, value in node_label_count.items():
-                node_count_by_label.append(
-                    {'label': key, 'count': value['count']}) 
-            for key, value in edge_label_count.items():
-                edge_count_by_label.append(
-                    {'label': key, 'count': value['count']})
-            
-        meta_data = {
-            "node_count": node_and_edge_count.get('total_nodes', 0),
-            "edge_count": node_and_edge_count.get('total_edges', 0),
-            "node_count_by_label": node_count_by_label if node_count_by_label else [],
-            "edge_count_by_label": edge_count_by_label if edge_count_by_label else []
-        }
-        
-        return meta_data
+        res = self.formatter.format_result(result, "metta", {"properties": True}, result_type='graph')
+        return (res['nodes'], res['edges'])
 
     def prepare_query_input(self, inputs, schema):
         result = []
@@ -402,8 +220,8 @@ class MeTTa_Query_Generator(QueryGeneratorInterface):
                     "target": f"{tgt_type} {tgt_id}"
                     })
         query = self.get_node_properties(result, schema)
-        result = self.run_query(query)
-        return result
+        res = self.run_query(query)
+        return res, result
 
     def parse_id(self, request):
         nodes = request["nodes"]

--- a/app/services/mork_generator.py
+++ b/app/services/mork_generator.py
@@ -8,7 +8,6 @@ from app import app, perf_logger
 from dotenv import load_dotenv
 import time
 import datetime
-from app.lib.result_formatter import Result_Formatter
 
 load_dotenv()
 
@@ -16,6 +15,7 @@ class MorkQueryGenerator:
     def __init__(self, dataset_path):
         self.server = self.connect()
         self.metta = MeTTa()
+        from app.lib.result_formatter import Result_Formatter
         self.formatter = Result_Formatter()
         # self.clear_space()
         # self.load_dataset(dataset_path)

--- a/app/services/mork_generator.py
+++ b/app/services/mork_generator.py
@@ -8,6 +8,7 @@ from app import app, perf_logger
 from dotenv import load_dotenv
 import time
 import datetime
+from app.lib.result_formatter import Result_Formatter
 
 load_dotenv()
 
@@ -15,6 +16,7 @@ class MorkQueryGenerator:
     def __init__(self, dataset_path):
         self.server = self.connect()
         self.metta = MeTTa()
+        self.formatter = Result_Formatter()
         # self.clear_space()
         # self.load_dataset(dataset_path)
 
@@ -235,217 +237,14 @@ class MorkQueryGenerator:
 
     def parse_and_serialize(self, input, schema, graph_components, result_type):
         if result_type == 'graph':
-            query, result, prev_result = self.prepare_query_input(input, schema)
-            tuples = metta_seralizer(result[0])
+            _, results, identifiers = self.prepare_query_input(input, schema)
+            input = (results, identifiers)
+        return self.formatter.format_result(input, "mork", graph_components, result_type)
 
-            if not tuples:
-                nodes, edges = self.parse_and_seralize_no_properties(prev_result)
-                return {"nodes": nodes, "edges": edges,
-                        "node_count": 0,
-                        "edge_count": 0,
-                        "node_count_by_label": [],
-                        "edge_count_by_label": []
-                }
-            else:
-                result = self.parse_and_serialize_properties(result, graph_components, result_type)
-            return result
-        else:
-            tt_res = input[0]
-            cbl_res = input[1]
-            meta_data = {}  # Initialize to avoid unbound variable
-
-            if tt_res:
-                meta_data = get_total_counts(input[0])
-
-            if cbl_res:
-                meta_data = get_count_by_label(input[1])
-
-            return {
-                "node_count": meta_data.get('node_count', 0),
-                "edge_count": meta_data.get('edge_count', 0),
-                "node_count_by_label": meta_data.get('node_count_by_label', []),
-                "edge_count_by_label": meta_data.get('edge_count_by_label', []),
-            }
-
-    def parse_and_serialize_properties(self, input, graph_components, result_type):
-        (nodes, edges, _, _, meta_data) = self.process_result(input, graph_components, result_type)
-        return {"nodes": nodes[0], "edges": edges[0],
-                "node_count": meta_data.get('node_count', 0),
-                "edge_count": meta_data.get('edge_count', 0),
-                "node_count_by_label": meta_data.get('node_count_by_label', []),
-                "edge_count_by_label": meta_data.get('edge_count_by_label', [])
-        }
-
-    def parse_and_seralize_no_properties(self, results):
-        nodes = set()
-        edges = []
-
-        for result in results:
-            if len(result) == 0:
-                return [], []
-            source = result.get('source')
-            target = result.get('target')
-            if source:
-                nodes.add(source)
-            if target:
-                nodes.add(target)
-
-            if source and target:
-                source_label = source.split(' ')[0]
-                target_label = target.split(' ')[0]
-                edges.append({
-                    "data": {
-                        "id": self.generate_id(),
-                        "edge_id": f'{source_label}_{result["predicate"]}_{target_label}',
-                        "label": result['predicate'],
-                        "source": source,
-                        "target": target
-                    }
-                })
-
-        nodes_list = []
-
-        for node in nodes:
-            nodes_list.append({
-                "data": {
-                    "id": node,
-                    "type": node.split(' ')[0]
-                }
-            })
-
-        return nodes_list, edges
-
-   # Won't work because of we don't try to parse node count and count by labels
-    def process_result(self, results, graph_components, result_type):
-        node_and_edge_count = {}
-        count_by_label = {}
-        nodes = []
-        edges = []
-        node_to_dict = {}
-        edge_to_dict = {}
-        meta_data = {}
-
-        if result_type == 'graph':
-            nodes, edges, node_to_dict, edge_to_dict = self.process_result_graph(
-                    results[0], graph_components)
-
-        if result_type == 'count':
-            if len(results) > 0:
-                node_and_edge_count = results[0]
-
-            if len(results) > 1:
-                count_by_label = results[1]
-
-            meta_data = self.process_result_count(
-                node_and_edge_count, count_by_label, graph_components)
-
-        return (nodes, edges, node_to_dict, edge_to_dict, meta_data)
-
-    def process_result_graph(self, results, graph_components):
-        nodes = {}
-        relationships_dict = {}
-        node_result = []
-        edge_result = []
-        node_to_dict = {}
-        edge_to_dict = {}
-        node_type = set()
-        edge_type = set()
-        tuples = metta_seralizer(results)
-
-        named_types = ['gene_name', 'transcript_name', 'protein_name',
-                        'pathway_name', 'term_name']
-
-        for match in tuples:
-            graph_attribute = match[0]
-            match = match[1:]
-
-            if graph_attribute == "node":
-                if len(match) > 4:
-                    predicate = match[0]
-                    src_type = match[1]
-                    src_value = match[2]
-                    tgt = list(match[3:])
-                else:
-                    predicate, src_type, src_value, tgt = match
-                if (src_type, src_value) not in nodes:
-                    nodes[(src_type, src_value)] = {
-                        "id": f"{src_type} {src_value}",
-                        "type": src_type,
-                    }
-
-                if graph_components['properties']:
-                     nodes[(src_type, src_value)][predicate] = tgt
-                else:
-                    if predicate in named_types:
-                        nodes[(src_type, src_value)]['name'] = tgt
-
-                if 'synonyms' in nodes[(src_type, src_value)]:
-                    del nodes[(src_type, src_value)]['synonyms']
-
-                if src_type not in node_type:
-                    node_type.add(src_type)
-                    node_to_dict[src_type] = []
-                node_data = {}
-                node_data["data"] = nodes[(src_type, src_value)]
-                node_to_dict[src_type].append(node_data)
-            elif graph_attribute == "edge":
-                property_name, predicate, source, source_id, target, target_id = match[:6]
-                value = ' '.join(match[6:])
-
-                key = (predicate, source, source_id, target, target_id)
-                if key not in relationships_dict:
-                    relationships_dict[key] = {
-                        "edge_id": f'{source}_{predicate}_{target}',
-                        "label": predicate,
-                        "source": f"{source} {source_id}",
-                        "target": f"{target} {target_id}",
-                    }
-
-                if property_name == "source":
-                    relationships_dict[key]["source_data"] = value
-                else:
-                    relationships_dict[key][property_name] = value
-
-                if predicate not in edge_type:
-                    edge_type.add(predicate)
-                    edge_to_dict[predicate] = []
-                edge_data = {}
-                edge_data['data'] = relationships_dict[key]
-                edge_to_dict[predicate].append(edge_data)
-        node_list = [{"data": node} for node in nodes.values()]
-        relationship_list = [{"data": relationship} for relationship in relationships_dict.values()]
-
-        node_result.append(node_list)
-        edge_result.append(relationship_list)
-        return (node_result, edge_result, node_to_dict, edge_to_dict)
-
-    def process_result_count(self, node_and_edge_count, count_by_label, graph_components):
-        if len(node_and_edge_count) != 0:
-            node_and_edge_count = node_and_edge_count[0].get_object().value
-        node_count_by_label = []
-        edge_count_by_label = []
-
-        if len(count_by_label) != 0:
-            count_by_label = count_by_label[0].get_object().value
-            node_label_count = count_by_label['node_label_count']
-            edge_label_count = count_by_label['edge_label_count']
-
-            # update the way node count by label and edge count by label are represented
-            for key, value in node_label_count.items():
-                node_count_by_label.append(
-                    {'label': key, 'count': value['count']})
-            for key, value in edge_label_count.items():
-                edge_count_by_label.append(
-                    {'label': key, 'count': value['count']})
-
-        meta_data = {
-            "node_count": node_and_edge_count.get('total_nodes', 0),
-            "edge_count": node_and_edge_count.get('total_edges', 0),
-            "node_count_by_label": node_count_by_label if node_count_by_label else [],
-            "edge_count_by_label": edge_count_by_label if edge_count_by_label else []
-        }
-
-        return meta_data
+    def convert_to_dict(self, results, schema=None):
+        query, result, prev_result = self.prepare_query_input(results, schema)
+        res = self.formatter.format_result((result, prev_result), "mork", {"properties": True}, result_type='graph')
+        return (res['nodes'], res['edges'])
 
     def parse_id(self, request):
         nodes = request["nodes"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,7 @@ nanoid==2.0.0
 elasticsearch==9.0.1
 pybind11>=2.10.0
 neo4j==5.28.0
+axiom-py==0.10.0
+sentry-sdk==2.58.0
+pymongo==4.10.1
+requests==2.32.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ networkx==3.4.2
 Flask-SocketIO==5.5.1
 flask-redis==0.4.0
 nanoid==2.0.0
-networkx==3.4.2
 elasticsearch==9.0.1
 pybind11>=2.10.0
+neo4j==5.28.0


### PR DESCRIPTION
## Description
This PR introduces a centralized **Result Formatter Pipeline** that unifies the parsing and formatting logic for all database backends (Neo4j, MeTTa, and Mork). Previously, each service generator handled its own response serialization, leading to logic duplication and inconsistent JSON structures.

### Key Architectural Changes
1.  **Unified Pipeline**: Implemented `app/lib/result_formatter.py` which uses a **Processor -> Formatter** pattern.
    *   **Processors**: Database-specific handlers (`_process_neo4j_graph`, `_process_metta_graph`) extract raw data into a standard internal dictionary.
    *   **Formatter**: A single method (`_format_graph_output`) ensures all responses follow the exact same frontend-compliant schema.
2.  **Type Safety**: Introduced `TypedDict` contracts (`UnifiedGraphOutput`, `ProcessedCount`) to enforce structural consistency at the code level.
3.  **Resilience**: Added a `_process_simple_graph` fallback mechanism. If property-fetching fails for MeTTa/Mork, the system gracefully builds a valid graph from identifiers instead of returning empty results.
4.  **Service Decoupling**: Service generators (`cypher_generator`, `metta_generator`, `mork_generator`) are now significantly leaner, delegating all formatting responsibility to the new library.

### Benefits
*   **Maintainability**: Adding a new database backend now only requires implementing one processor method in the (result_formatter) library.
*   **Consistency**: Guarantees that regardless of the data source, the frontend receives a uniform JSON structure.