### PR TITLE
feat: add hash-based query deduplication

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,7 +30,7 @@ logging.getLogger('werkzeug').disabled = True
 socketio = SocketIO(app, cors_allowed_origins='*',
                     async_mode='threading', logger=False, engineio_logger=False)
 
-app.config['REDIS_URL'] = os.getenv('REDIS_URL')
+app.config['REDIS_URL'] = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
 
 # intialize redis
 redis_client = FlaskRedis(app)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -103,4 +103,4 @@ graph_info = json.load(open(GRAPH_INFO_PATH))
 
 # Import routes at the end to avoid circular imports
 from app import routes
-from app.annotation_controller import handle_client_request, process_full_data, requery
+from app.annotation_controller import handle_client_request, process_full_data

--- a/app/annotation_controller.py
+++ b/app/annotation_controller.py
@@ -17,45 +17,69 @@ EXP = os.getenv('REDIS_EXPIRATION', 3600) # expiration time of redis cache
 
 def handle_client_request(query, request, current_user_id, node_types, species, data_source):
     annotation_id = request.get('annotation_id', None)
-    # check if annotation exist
+    
+    # Check for existing result globally using deduplication
+    from app.services.query_deduplicator import QueryDeduplicator
+    existing_query, query_hash = QueryDeduplicator.get_existing_result(request, species, data_source)
 
-    if annotation_id:
-        existing_query = AnnotationStorageService.get_user_query(
-            annotation_id, str(current_user_id), query[0])
-    else:
-        existing_query = None
-
-    #Event to track tasks
+    # Event to track tasks
     result_done = threading.Event()
     total_count_done = threading.Event()
     label_count_done = threading.Event()
 
-    if existing_query:
+    if existing_query and existing_query.status == TaskStatus.COMPLETE.value:
+        # --- DEDUPLICATION HIT (COMPLETE) ---
         title = existing_query.title
         summary = existing_query.summary
-        annotation_id = existing_query.id
-        meta_data = {
-            "node_count": existing_query.node_count,
-            "edge_count": existing_query.edge_count,
-            "node_count_by_label": existing_query.node_count_by_label,
-            "edge_count_by_label": existing_query.edge_count_by_label,
-        }
-        AnnotationStorageService.update(
-            annotation_id, {"status": TaskStatus.PENDING.value, "updated_at": datetime.datetime.now()})
-        reset_status(annotation_id)
+        path_url = existing_query.path_url
+        
+        if annotation_id:
+            # Point existing annotation to the shared result
+            AnnotationStorageService.update(annotation_id, {
+                "status": TaskStatus.COMPLETE.value,
+                "query": query[0],
+                "query_hash": query_hash,
+                "title": title,
+                "summary": summary,
+                "node_count": existing_query.node_count,
+                "edge_count": existing_query.edge_count,
+                "node_count_by_label": existing_query.node_count_by_label,
+                "edge_count_by_label": existing_query.edge_count_by_label,
+                "path_url": path_url,
+                "updated_at": datetime.datetime.now()
+            })
+        else:
+            # Create a new pointer for this user
+            annotation = {
+                "current_user_id": str(current_user_id),
+                "query": query[0],
+                "query_hash": query_hash,
+                "request": request,
+                "title": title,
+                "summary": summary,
+                "node_types": node_types,
+                "node_count": existing_query.node_count,
+                "edge_count": existing_query.edge_count,
+                "node_count_by_label": existing_query.node_count_by_label,
+                "edge_count_by_label": existing_query.edge_count_by_label,
+                "status": TaskStatus.COMPLETE.value,
+                "path_url": path_url,
+                "data_source": data_source,
+                "species": species
+            }
+            annotation_id = AnnotationStorageService.save(annotation)
 
-        args = {'all_status': {'result_done': result_done, 'total_count_done': total_count_done,
-                               'label_count_done': label_count_done}, 'query': query, 'request': request,
-                'summary': summary, 'meta_data': meta_data, 'data_source': data_source, 'species': species}
-
-        start_thread(annotation_id, args)
+        # Work is done. No need to start threads.
         return Response(
             json.dumps({"annotation_id": str(annotation_id)}),
             mimetype='application/json')
-    elif annotation_id is None:
+
+    # --- DEDUPLICATION MISS OR PENDING ---
+    if annotation_id is None:
         title = llm.generate_title(query[0])
         annotation = {"current_user_id": str(current_user_id),
                       "query": str(query[0]), "request": request,
+                      "query_hash": query_hash,
                       "title": title, "node_types": node_types,
                       "status": TaskStatus.PENDING.value,
                       "data_source": data_source, "species": species}
@@ -64,7 +88,7 @@ def handle_client_request(query, request, current_user_id, node_types, species, 
 
         args = {'all_status': {'result_done': result_done, 'total_count_done': total_count_done,
                                'label_count_done': label_count_done}, 'query': query, 'request': request,
-                'summary': None, 'meta_data': None, 'data_source': data_source, 'species': species}
+                'summary': None, 'meta_data': None, 'data_source': data_source, 'species': species, 'query_hash': query_hash}
         start_thread(annotation_id, args)
 
         return Response(
@@ -75,6 +99,7 @@ def handle_client_request(query, request, current_user_id, node_types, species, 
         del request['annotation_id']
         # save the query and return the annotation
         annotation = {"query": str(query[0]), "request": request,
+                      "query_hash": query_hash,
                       "title": title, "node_types": node_types,
                       'status': TaskStatus.PENDING.value, 'node_count': None,
                       'edge_count': None, 'node_count_by_label': None,
@@ -85,7 +110,7 @@ def handle_client_request(query, request, current_user_id, node_types, species, 
 
         args = {'all_status': {'result_done': result_done, 'total_count_done': total_count_done,
                                'label_count_done': label_count_done}, 'query': query, 'request': request,
-                'summary': None, 'meta_data': None, 'species': species}
+                'summary': None, 'meta_data': None, 'species': species, 'query_hash': query_hash}
 
         start_thread(annotation_id, args)
 

--- a/app/lib/canonicalizer.py
+++ b/app/lib/canonicalizer.py
@@ -1,0 +1,35 @@
+import json
+import hashlib
+
+class Canonicalizer:
+    @staticmethod
+    def canonicalize(request_data, species, data_source):
+        """
+        Normalizes a graph query request into a stable hash.
+        """
+        nodes = request_data.get('nodes', [])
+        predicates = request_data.get('predicates', [])
+        
+        # Build sorting key and sort nodes
+        def node_sort_key(node):
+            node_type = node.get('type', '')
+            props = json.dumps(node.get('properties', {}), sort_keys=True)
+            return (node_type, props)
+        
+        sorted_nodes = sorted(nodes, key=node_sort_key)
+        
+        # Map old IDs to canonical IDs (node_0, node_1...)
+        id_mapping = {}
+        canonical_nodes = []
+        for i, node in enumerate(sorted_nodes):
+            old_id = node.get('id')
+            new_id = f"node_{i}"
+            id_mapping[old_id] = new_id
+            
+            canonical_nodes.append({
+                "id": new_id,
+                "type": node.get('type', ''),
+                "properties": node.get('properties', {})
+            })
+            
+ 

--- a/app/lib/canonicalizer.py
+++ b/app/lib/canonicalizer.py
@@ -32,4 +32,31 @@ class Canonicalizer:
                 "properties": node.get('properties', {})
             })
             
- 
+        # Rewrite predicates using new IDs
+        canonical_predicates = []
+        for p in predicates:
+            canonical_predicates.append({
+                "source": id_mapping.get(p.get('source'), p.get('source')),
+                "target": id_mapping.get(p.get('target'), p.get('target')),
+                "type": p.get('type', ''),
+                "properties": p.get('properties', {})
+            })
+            
+        # Sort predicates to ensure stable order
+        def predicate_sort_key(p):
+            props = json.dumps(p.get('properties', {}), sort_keys=True)
+            return (p.get('source'), p.get('target'), p.get('type'), props)
+            
+        canonical_predicates.sort(key=predicate_sort_key)
+        
+        # Final canonical object
+        canonical_query = {
+            "species": species,
+            "data_source": data_source,
+            "nodes": canonical_nodes,
+            "predicates": canonical_predicates
+        }
+        
+        # Stable JSON string and Hashing
+        canonical_str = json.dumps(canonical_query, sort_keys=True)
+        return hashlib.sha256(canonical_str.encode('utf-8')).hexdigest()

--- a/app/models/annotation.py
+++ b/app/models/annotation.py
@@ -25,6 +25,7 @@ class Annotation(Schema):
     data_source = None
     species = None
     path_url = None
+    query_hash = None
 
     def __init__(self, **kwargs):
         self.schema = {
@@ -67,6 +68,10 @@ class Annotation(Schema):
                 "required": True
             },
             "path_url": Types.String,
+            "query_hash": {
+                "type": Types.String,
+                "required": False,
+            },
             "species": {
                 "type": Types.String,
                 "required": True,

--- a/app/persistence/annotation_storage_service.py
+++ b/app/persistence/annotation_storage_service.py
@@ -22,7 +22,9 @@ class AnnotationStorageService():
             edge_count_by_label=annotation.get("edge_count_by_label", None),
             status=annotation.get('status', 'PENDING'),
             species=annotation.get('species', 'human'),
-            data_source=annotation.get('data_source', 'all')
+            data_source=annotation.get('data_source', 'all'),
+            query_hash=annotation.get('query_hash', None),
+            path_url=annotation.get('path_url', None)
         )
 
         id = data.save()
@@ -54,6 +56,14 @@ class AnnotationStorageService():
     def get_user_annotation(annotation_id, user_id):
         data = Annotation.find_one({"_id": annotation_id, "user_id": user_id})
         return data
+
+    @staticmethod
+    def find_by_hash(query_hash):
+        data = Annotation.find({
+            "query_hash": query_hash,
+            "status": "COMPLETE"
+        }).sort('_id', -1).limit(1)
+        return data[0] if data else None
 
     @staticmethod
     def update(id, data):

--- a/app/routes.py
+++ b/app/routes.py
@@ -18,9 +18,9 @@ from dotenv import load_dotenv
 from distutils.util import strtobool
 import datetime
 from app.lib import Graph, heuristic_sort
-from app.annotation_controller import handle_client_request, process_full_data, requery
+from app.annotation_controller import handle_client_request, process_full_data
 from app.constants import TaskStatus, Species, form_fields, ROLES
-from app.workers.task_handler import get_annotation_redis
+from app.workers.task_handler import get_annotation_redis, get_graph_file_path
 from app.persistence import AnnotationStorageService, UserStorageService, SharedAnnotationStorageService
 from nanoid import generate
 from app.lib.utils import convert_to_tsv
@@ -485,9 +485,18 @@ def process_query(current_user_id):
         response['node_count_by_label'] = meta_data['node_count_by_label']
         response['edge_count_by_label'] = meta_data['edge_count_by_label']
 
+        # Points to Compute hash and store globally
+        from app.lib.canonicalizer import Canonicalizer
+        query_hash = Canonicalizer.canonicalize(requests, species, data_source)
+        graph_data = {'nodes': response['nodes'], 'edges': response['edges']}
+        graph_file_path = get_graph_file_path(query_hash)
+        with open(graph_file_path, 'w') as file:
+            json.dump(graph_data, file)
+
         annotation = {"current_user_id": str(current_user_id),
                       "request": requests,
                       "query": result_query,
+                      "query_hash": query_hash,
                       "title": title,
                       "summary": summary,
                       "node_count": response['node_count'],
@@ -496,14 +505,17 @@ def process_query(current_user_id):
                       "node_count_by_label": response['node_count_by_label'],
                       "edge_count_by_label": response['edge_count_by_label'],
                       "answer": answer, "question": question,
-                      "status": TaskStatus.COMPLETE.value
+                      "status": TaskStatus.COMPLETE.value,
+                      "path_url": str(graph_file_path.resolve())
                       }
 
         annotation_id = AnnotationStorageService.save(annotation)
-        redis_client.setex(str(annotation_id), EXP, json.dumps({'task': 4,
-                                'graph': {'nodes': response['nodes'], 'edges': response['edges']}}))
-        response = {"annotation_id": str(
-            annotation_id), "question": question, "answer": answer}
+        
+        # Save to Global Redis Cache
+        redis_client.setex(f"query_hash:{query_hash}", EXP, json.dumps({
+                                'graph': graph_data}))
+        
+        response = {"annotation_id": str(annotation_id), "question": question, "answer": answer}
         formatted_response = json.dumps(response, indent=4)
         
         logging.info(json.dumps({"status": "success", "method": "POST",
@@ -740,11 +752,16 @@ def get_by_id(current_user_id, id):
             response_data["edge_count_by_label"] = edge_count_by_label
         response_data["status"] = status
 
-        cache = redis_client.get(str(annotation_id))
+        # Points annotation_id → query_hash → global result
+        query_hash = cursor.query_hash
+        if not query_hash:
+            logging.error(f"Annotation {annotation_id} missing query_hash — corrupted record")
+            return Response(json.dumps({"error": "Corrupted annotation record"}), mimetype='application/json', status=500)
+        cache = redis_client.get(f"query_hash:{query_hash}")
 
         if cache is not None:
             cache = json.loads(cache)
-            graph = cache['graph']
+            graph = cache.get('graph')
             if graph is not None:
                 response_data['nodes'] = graph['nodes']
                 response_data['edges'] = graph['edges']
@@ -753,16 +770,17 @@ def get_by_id(current_user_id, id):
 
         if status in [TaskStatus.PENDING.value, TaskStatus.COMPLETE.value]:
             if status == TaskStatus.COMPLETE.value:
-                if os.path.exists(file_path):
+                if file_path and os.path.exists(file_path):
                     # open the file and read the graph
                     with open(file_path, 'r') as file:
                         graph = json.load(file)
 
                     response_data['nodes'] = graph['nodes']
                     response_data['edges'] = graph['edges']
+                    redis_client.setex(f"query_hash:{query_hash}", EXP, json.dumps({'graph': graph}))
                 else:
                     response_data['status'] = TaskStatus.PENDING.value
-                    requery(annotation_id, query, json_request)
+                    AnnotationStorageService.update(annotation_id, {"status": TaskStatus.PENDING.value})
             formatted_response = json.dumps(response_data, indent=4)
             return Response(formatted_response, mimetype='application/json')
 
@@ -850,19 +868,31 @@ def process_by_id(current_user_id, id):
     json_request = cursor.request
     node_count_by_label = cursor.node_count_by_label
     edge_count_by_label = cursor.edge_count_by_label
+    file_path = cursor.path_url
 
     try:
         if question:
             response_data["question"] = question
 
-        cache = redis_client.get(str(id))
+        # points annotation_id → query_hash → global result
+        query_hash = cursor.query_hash
+        if not query_hash:
+            logging.error(f"Annotation {id} missing query_hash — corrupted record")
+            return Response(json.dumps({"error": "Corrupted annotation record"}), mimetype='application/json', status=500)
+        cache = redis_client.get(f"query_hash:{query_hash}")
 
         if cache is not None:
             cache = json.loads(cache)
-            graph = cache['graph']
+            graph = cache.get('graph')
             if graph is not None:
                 response_data['nodes'] = graph['nodes']
                 response_data['edges'] = graph['edges']
+        elif cursor.status == TaskStatus.COMPLETE.value and file_path and os.path.exists(file_path):
+            with open(file_path, 'r') as file:
+                graph = json.load(file)
+            response_data['nodes'] = graph['nodes']
+            response_data['edges'] = graph['edges']
+            redis_client.setex(f"query_hash:{query_hash}", EXP, json.dumps({'graph': graph}))
         else:
             # Run the query and parse the results
             result = db_instance.run_query(query)
@@ -1373,8 +1403,13 @@ def cell_component(current_user_id):
 
     try:
         # get the graph and filter out the protein
-        file_name = f'{annotation_id}.json'
-        path = Path(__file__).parent /".."/ "public" / "graph" / f"{file_name}"
+        annotation = AnnotationStorageService.get_user_annotation(annotation_id, current_user_id)
+        if annotation is None:
+            return jsonify('No value Found'), 404
+
+        path = annotation.path_url
+        if not path or not os.path.exists(path):
+            return jsonify('Graph file not found'), 404
 
         with open(path, 'r') as f:
             graph = json.load(f)
@@ -1578,12 +1613,14 @@ def cell_component(current_user_id):
 @app.route('/annotation/<id>/download-tsv', methods=['GET'])
 @token_required
 def download_csv(current_user_id, id):
-    cursor = cursor = storage_service.get_by_id(id)
+    cursor = AnnotationStorageService.get_user_annotation(id, current_user_id)
     
     if cursor is None:
         return jsonify('No value Found'), 404
 
     file_path = cursor.path_url
+    if not file_path or not os.path.exists(file_path):
+        return jsonify('Graph file not found'), 404
     
     try:
         graph = json.load(open(file_path))

--- a/app/services/query_deduplicator.py
+++ b/app/services/query_deduplicator.py
@@ -1,0 +1,29 @@
+from app.lib.canonicalizer import Canonicalizer
+from app.persistence.annotation_storage_service import AnnotationStorageService
+from app.constants import TaskStatus
+
+class QueryDeduplicator:
+    @staticmethod
+    def get_existing_result(request_data, species, data_source):
+        """
+        Checks if a result for the given query already exists in the system.
+        
+        Args:
+            request_data (dict): The 'requests' object from the frontend.
+            species (str): The species context.
+            data_source (str): The data source context.
+            
+        Returns:
+            Annotation: The existing annotation document if found, else None.
+            str: The query hash.
+        """
+        query_hash = Canonicalizer.canonicalize(request_data, species, data_source)
+        
+        # Check MongoDB for any previous annotation with this hash
+        existing_annotation = AnnotationStorageService.find_by_hash(query_hash)
+        
+        # We ONLY share results that are already COMPLETE.
+        if existing_annotation and existing_annotation.status == TaskStatus.COMPLETE.value:
+            return existing_annotation, query_hash
+                
+        return None, query_hash

--- a/app/workers/task_handler.py
+++ b/app/workers/task_handler.py
@@ -14,7 +14,12 @@ import traceback
 llm = app.config['llm_handler']
 EXP = os.getenv('REDIS_EXPIRATION', 3600) # expiration time of redis cache
 
-def update_task(annotation_id, graph=None):
+def get_graph_file_path(query_hash):
+    graph_dir = Path(__file__).parent / ".." / ".." / "public" / "graph"
+    graph_dir.mkdir(parents=True, exist_ok=True)
+    return graph_dir / f"{query_hash}.json"
+
+def update_task(annotation_id, query_hash=None, graph=None):
     with app.config['annotation_lock']:
         status = TaskStatus.PENDING.value
         # Get the cached data (Handle case where cache is None)
@@ -22,42 +27,41 @@ def update_task(annotation_id, graph=None):
 
         cache = json.loads(cache) if cache else {'graph': None, 'status': status}
 
-        status = cache['status']
+        status = cache.get('status', TaskStatus.PENDING.value)
         # Merge graph updates
-        graph = graph if graph else cache['graph']
-        if status == TaskStatus.COMPLETE.value:
-            redis_client.setex(str(annotation_id), EXP, json.dumps({
-                'graph': graph, 'status': TaskStatus.COMPLETE.value
+        graph = graph if graph is not None else cache.get('graph')
+        
+        if status in [TaskStatus.FAILED.value, TaskStatus.CANCELLED.value]:
+            redis_client.set(str(annotation_id), json.dumps({
+                'graph': graph, 'status': status
             }))
             AnnotationStorageService.update(annotation_id, {'status': status})
-            redis_client.delete(f"{annotation_id}_tasks")
-            return TaskStatus.COMPLETE.value
+            return status
 
         # Increment task count atomically and get the new count
         task_num = redis_client.incr(f"{annotation_id}_tasks")
 
-        if status in [TaskStatus.FAILED.value, TaskStatus.CANCELLED.value]:
-            if task_num >= 4 and cache['status'] == TaskStatus.CANCELLED.value:
-                AnnotationStorageService.delete(annotation_id)
-                redis_client.delete(f"{annotation_id}_tasks")
-                redis_client.delete(str(annotation_id))
-                with app.config['annotation_lock']:
-                    annotation_threads = app.config['annotation_threads']
-                    del annotation_threads[str(annotation_id)]
-        else:
-            status = TaskStatus.COMPLETE.value if task_num >= 4 else TaskStatus.PENDING.value
-        if status in [TaskStatus.FAILED.value, TaskStatus.COMPLETE.value] and task_num >= 4:
+        if task_num >= 4:
+            status = TaskStatus.COMPLETE.value
+            # If we finished, save the result to BOTH the WebSocket cache (for the active user)
+            # and the Shared Global cache (for the deduplication pool)
+            if query_hash and graph is not None:
+                redis_client.setex(f"query_hash:{query_hash}", EXP, json.dumps({'graph': graph}))
+
             redis_client.setex(str(annotation_id), EXP, json.dumps({
-                'graph': graph, 'status': status
-            }))
-            AnnotationStorageService.update(annotation_id, {'status': status})
-            redis_client.delete(f"{annotation_id}_tasks")
-        elif status == TaskStatus.PENDING.value:
-            redis_client.set(str(annotation_id), json.dumps({
-                'graph': graph, 'status': status
+                'graph': graph, 'status': TaskStatus.COMPLETE.value
             }))
 
-        return status
+            AnnotationStorageService.update(annotation_id, {'status': TaskStatus.COMPLETE.value})
+            redis_client.delete(f"{annotation_id}_tasks")
+            return TaskStatus.COMPLETE.value
+
+        else:
+            # Still pending
+            redis_client.set(str(annotation_id), json.dumps({
+                'graph': graph, 'status': TaskStatus.PENDING.value
+            }))
+            return TaskStatus.PENDING.value
 
 def get_status(annotation_id):
     with app.config['annotation_lock']:
@@ -158,7 +162,7 @@ def generate_summary(annotation_id, request, all_status, summary=None):
                         'update': {'summary': 'Graph too big, could not summarize'}},
                       to=str(annotation_id))
 
-def generate_result(query_code, annotation_id, requests, result_status, species, status=None,):
+def generate_result(query_code, annotation_id, requests, result_status, species, query_hash):
 
     try:
         annotation_threads = app.config['annotation_threads']
@@ -185,17 +189,14 @@ def generate_result(query_code, annotation_id, requests, result_status, species,
         else:
             grouped_graph = graph.group_graph(response);
 
-        file_path = Path(__file__).parent /".."/ ".."/ "public" / "graph" / f"{annotation_id}.json"
+        file_path = get_graph_file_path(query_hash)
 
         with open(file_path, 'w') as file:
             json.dump(grouped_graph, file)
 
         AnnotationStorageService.update(annotation_id, {"path_url": str(file_path.resolve())})
 
-        if status:
-            set_status(annotation_id, status);
-
-        status = update_task(annotation_id, {
+        status = update_task(annotation_id, query_hash, {
             'nodes': grouped_graph['nodes'],
             'edges': grouped_graph['edges']
         })
@@ -209,7 +210,7 @@ def generate_result(query_code, annotation_id, requests, result_status, species,
         return grouped_graph
     except ThreadStopException as e:
         set_status(annotation_id, TaskStatus.CANCELLED.value)
-        update_task(annotation_id, {
+        update_task(annotation_id, query_hash, {
             "nodes": [],
             "edges": []
         })
@@ -536,7 +537,7 @@ def generate_label_count(
         logging.error("Error generating result graph %s", e)
     except Exception as e:
         set_status(annotation_id, "FAILED")
-        update_task(annotation_id)
+        update_task(annotation_id, query_hash)
 
         update = generate_empty_lable_count(requests)
         AnnotationStorageService.update(
@@ -554,6 +555,7 @@ def generate_label_count(
 
 def start_thread(annotation_id, args):
     all_status = args['all_status']
+    query_hash = args.get('query_hash')
     find_query = args['query'][0]
     total_count_query = args['query'][1]
     label_count_query = args['query'][2]
@@ -567,7 +569,7 @@ def start_thread(annotation_id, args):
 
     def send_annotation():
         try:
-            generate_result(find_query, annotation_id, request, all_status['result_done'], species)
+            generate_result(find_query, annotation_id, request, query_hash, all_status['result_done'], species)
         except Exception as e:
             logging.error("Error generating result graph %s", e)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ neo4j==5.20.0
 axiom-py==0.10.0
 pandas==2.2.3
 requests==2.32.5
-sentry-sdk==1.54.0
+sentry-sdk==2.58.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ networkx==3.4.2
 elasticsearch==9.0.1
 pybind11>=2.10.0
 neo4j==5.20.0
-axiom-py==0.3.6
+axiom-py==0.10.0
 pandas==2.2.3
 requests==2.32.5
 sentry-sdk==1.54.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,7 @@ networkx==3.4.2
 elasticsearch==9.0.1
 pybind11>=2.10.0
 neo4j==5.20.0
+axiom-py==0.3.6
+pandas==2.2.3
+requests==2.32.5
+sentry-sdk==1.54.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ nanoid==2.0.0
 networkx==3.4.2
 elasticsearch==9.0.1
 pybind11>=2.10.0
+neo4j==5.20.0


### PR DESCRIPTION
## Overview                                                                                                                    
                                                                                                                                 
  This PR adds query-level deduplication for annotation results. Incoming graph requests are canonicalized into a stable         
  `query_hash`, allowing structurally equivalent queries from different users to reuse completed results instead of triggering   
  duplicate backend execution.
                                                                                                                                 
  ## Architecture                                                                                                                
                                                                                                                                 
  1. **Canonicalization**                                                                                                        
     Adds `app/lib/canonicalizer.py` to normalize frontend-generated node and predicate IDs, sort query structure                
  deterministically, and produce a stable SHA256 `query_hash`.                                                                   
                                                                                                                                 
  2. **Deduplication Check**                                                                                                     
     Adds `QueryDeduplicator` to look up existing completed annotations by `query_hash`. Only `COMPLETE` results are shared;     
  pending or failed matches still run as independent executions for isolation.                                                   

  3. **Pointer Model**
     User annotations now store `query_hash` and `path_url`, so each user keeps their own `annotation_id` and history entry while
  pointing to the shared completed graph result.                                                                                 
                                                                                                                                 
  4. **Shared Result Storage**                                                                                                   
     Completed graph results are stored in:                                                                                      
     - Redis under `query_hash:<hash>` as a temporary hot cache                                                                  
     - Disk under `public/graph/<query_hash>.json` as the durable graph artifact                                                 
     - MongoDB as metadata plus pointers, not the full graph payload                                                             
                                                                                                                                 
  5. **Read Path Updates**                                                                                                       
     Annotation read paths now prefer Redis for fast access and fall back to the durable disk artifact through `path_url` when   
  Redis has expired.                                                                                                             
                                                                                                                                 
  ## Impact                                                                                                                      
                                                                                                                                 
  - Reduces duplicate graph query execution for completed equivalent queries                                                     
  - Preserves per-user annotation history and ownership                                                                          
  - Keeps pending and failed executions isolated per annotation                                                                  
  - Clarifies storage responsibilities across MongoDB, Redis, and disk artifacts                                                 