### PR TITLE
feat(mork): implement HTTP-aware self-healing and circuit breaker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,10 @@ SENTRY_DSN=your-sentry-dsn
 # Axiom for logging
 AXIOM_DATASET=your-dataset
 AXIOM_TOKEN=your-token
+
+# ==================== MORK RESILIENCE ====================
+MORK_RETRY_ATTEMPTS=5
+MORK_RETRY_MIN_WAIT=1
+MORK_RETRY_MAX_WAIT=10
+MORK_BREAKER_FAIL_MAX=5
+MORK_BREAKER_RESET_TIMEOUT=30

--- a/app/error.py
+++ b/app/error.py
@@ -1,3 +1,25 @@
 class ThreadStopException(Exception):
     def __init__(self, message):
         super().__init__(message)
+
+import requests.exceptions
+
+MORK_TRANSIENT_EXCEPTIONS = (
+    requests.exceptions.ConnectionError,
+    requests.exceptions.Timeout,
+    requests.exceptions.ConnectTimeout,
+    requests.exceptions.ReadTimeout,
+    requests.exceptions.ChunkedEncodingError,
+)
+
+def is_mork_transient(exc: Exception) -> bool:
+    """Returns True if the exception is a temporary MORK network glitch."""
+    if isinstance(exc, MORK_TRANSIENT_EXCEPTIONS):
+        return True
+
+    if isinstance(exc, requests.exceptions.HTTPError):
+        response = getattr(exc, "response", None)
+        if response is not None:
+            return response.status_code in {429, 500, 502, 503, 504}
+
+    return False

--- a/app/services/mork_generator.py
+++ b/app/services/mork_generator.py
@@ -11,6 +11,25 @@ import datetime
 
 load_dotenv()
 
+from app.error import is_mork_transient
+from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception
+import pybreaker
+
+# Resilience Configuration
+MORK_RETRY_ATTEMPTS = int(os.getenv("MORK_RETRY_ATTEMPTS", 5))
+MORK_RETRY_MIN_WAIT = int(os.getenv("MORK_RETRY_MIN_WAIT", 1))
+MORK_RETRY_MAX_WAIT = int(os.getenv("MORK_RETRY_MAX_WAIT", 10))
+MORK_BREAKER_FAIL_MAX = int(os.getenv("MORK_BREAKER_FAIL_MAX", 5))
+MORK_BREAKER_RESET_TIMEOUT = int(os.getenv("MORK_BREAKER_RESET_TIMEOUT", 30))
+
+def exclude_non_transient(e):
+    return not is_mork_transient(e)
+
+mork_breaker = pybreaker.CircuitBreaker(
+    fail_max=MORK_BREAKER_FAIL_MAX, 
+    reset_timeout=MORK_BREAKER_RESET_TIMEOUT,
+    exclude=[exclude_non_transient]
+)
 class MorkQueryGenerator:
     def __init__(self, dataset_path):
         self.server = self.connect()
@@ -52,6 +71,13 @@ class MorkQueryGenerator:
             node_representation += f' ({key} ({node_type + " " + identifier}) {value})'
         return node_representation
 
+    @mork_breaker
+    @retry(
+        stop=stop_after_attempt(MORK_RETRY_ATTEMPTS),
+        wait=wait_exponential(multiplier=1, min=MORK_RETRY_MIN_WAIT, max=MORK_RETRY_MAX_WAIT),
+        retry=retry_if_exception(is_mork_transient),
+        reraise=True
+    )
     def run_query(self, query, stop_event=None, species='human'):
         with app.config["annotation_lock"]:
             start_time = time.time()

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,5 @@ nanoid==2.0.0
 networkx==3.4.2
 elasticsearch==9.0.1
 pybind11>=2.10.0
+tenacity==9.1.4
+pybreaker==1.4.1


### PR DESCRIPTION
### Description
This PR adds a safety net to our MORK server HTTP requests. Previously, if the MORK server experienced a temporary infrastructure hiccup or returned a 503 error, the backend would fail instantly. This PR introduces an intelligent retry loop and circuit breaker, ensuring that temporary network drops are handled seamlessly while actively preventing us from hammering a sick dependency.

### Changes
| Commit | Description |
| :--- | :--- |
| `67ce5c2` | Add `tenacity` (for retries) and `pybreaker` (for circuit breaking) |
| `67da7e4` | Create HTTP-aware `is_mork_transient` exception classifier in `app/error.py` |
| `fd3aaa6` | Add Mork threshold variables to `.env.example` so Ops can tune timeouts |
| `f1c8c29` | Wrap `run_query` with the retry and circuit breaker logic |

### Technical Implementation
* **Automated Reconnection (Tenacity):** Implements an exponential backoff retry loop on the core `run_query` execution path. It allows the system to seamlessly survive temporary network fluctuations.
* **Intelligent Failure Detection (PyBreaker):** Wraps the retry loop in a Circuit Breaker pattern. Because we use `reraise=True` on the retry loop, PyBreaker correctly monitors the final result. If the limit is reached, the circuit "trips" and immediately rejects new requests, allowing the Mork server to recover.
* **HTTP-Aware Error Classification:** The `is_mork_transient` filter explicitly targets base network transport exceptions (e.g., `ConnectTimeout`, `ChunkedEncodingError`) AND inspects `requests.exceptions.HTTPError` payloads to verify if the status code indicates a temporary server failure (`429`, `500`, `502`, `503`, `504`). True application errors (like a `400` or `404`) bypass the retry logic entirely.
* **Configuration-Driven Tuning:** Extracts all threshold logic (`fail_max`, `reset_timeout`, `wait_exponential` limits) into environment variables.

### Breaking Changes
**None.** This strictly wraps existing query logic in a safety net; it does not change any endpoints, data structures, or external API responses.